### PR TITLE
v3 remaining changes

### DIFF
--- a/lib/iiif/v3/presentation.rb
+++ b/lib/iiif/v3/presentation.rb
@@ -20,8 +20,10 @@ require_relative 'ordered_hash'
 module IIIF
   module V3
     module Presentation
-      # TODO: when v3 is baked, there will be a context
-      # CONTEXT ||= 'http://iiif.io/api/presentation/2/context.json'
+      CONTEXT ||= [
+       'http://www.w3.org/ns/anno.jsonld',
+       'http://iiif.io/api/presentation/3/context.json'
+      ]
 
       class MissingRequiredKeyError < StandardError; end
       class IllegalValueError < StandardError; end

--- a/lib/iiif/v3/presentation/abstract_resource.rb
+++ b/lib/iiif/v3/presentation/abstract_resource.rb
@@ -47,9 +47,9 @@ module IIIF
         end
 
         # Initialize a Presentation node
-        # @param [Hash] hsh - Anything in this hash will be added to the Object.'
+        # @param [Hash] hsh - Anything in this hash will be added to the Object.
         #   Order is only guaranteed if an ActiveSupport::OrderedHash is passed.
-        # @param [boolean] include_context (default: false). Pass true if the'
+        # @param [boolean] include_context (default: false). Pass true if the
         #   context should be included.
         def initialize(hsh={})
           if self.class == IIIF::V3::Presentation::AbstractResource
@@ -66,11 +66,10 @@ module IIIF
         #  * sort_json_ld_keys: (true|false). Brings all properties starting with
         #      '@'. Default: true. to the top of the document and sorts them.
         def to_ordered_hash(opts={})
-          # TODO: when v3 is baked, there will be a context
-          # include_context = opts.fetch(:include_context, true)
-          # if include_context && !self.has_key?('@context')
-          #   self['@context'] = IIIF::V3::Presentation::CONTEXT
-          # end
+          include_context = opts.fetch(:include_context, true)
+          if include_context && !self.has_key?('@context')
+            self['@context'] = IIIF::V3::Presentation::CONTEXT
+          end
           super(opts)
         end
 

--- a/lib/iiif/v3/presentation/annotation.rb
+++ b/lib/iiif/v3/presentation/annotation.rb
@@ -12,7 +12,7 @@ module IIIF
         end
 
         def abstract_resource_only_keys
-          super + [ { key: 'resource', type: IIIF::V3::Presentation::Resource } ]
+          super + [ { key: 'body', type: IIIF::V3::Presentation::Resource } ]
         end
 
         def initialize(hsh={})

--- a/lib/iiif/v3/presentation/image_resource.rb
+++ b/lib/iiif/v3/presentation/image_resource.rb
@@ -7,7 +7,7 @@ module IIIF
     module Presentation
       class ImageResource < Resource
 
-        TYPE = 'dctypes:Image'
+        TYPE = 'Image'
 
         def int_only_keys
           super + %w{ width height }
@@ -50,8 +50,8 @@ module IIIF
           #
           # {
           #   "id":"http://www.example.org/iiif/book1/res/page1.jpg",
-          #   "type":"dctypes:Image",
-          #   "format":"image/jpeg",
+          #   "type": "Image",
+          #   "format": "image/jpeg",
           #   "service": {
           #     "@context": "http://iiif.io/api/image/2/context.json",
           #     "id":"http://www.example.org/images/book1-page1",

--- a/lib/iiif/v3/presentation/range.rb
+++ b/lib/iiif/v3/presentation/range.rb
@@ -12,7 +12,7 @@ module IIIF
         end
 
         def array_only_keys
-          super + %w{ ranges }
+          super + %w{ members }
         end
 
         def legal_viewing_hint_values
@@ -25,7 +25,7 @@ module IIIF
         end
 
         def validate
-          # Values of the ranges array must be strings
+          # Values of the members array must be canvas or range
         end
       end
     end

--- a/lib/iiif/v3/service.rb
+++ b/lib/iiif/v3/service.rb
@@ -209,7 +209,7 @@ module IIIF
           new_key = key.underscore == key ? key : key.underscore
           if new_key == 'service'
             new_object[new_key] = IIIF::V3::Service.from_ordered_hash(hsh[key], IIIF::V3::Service)
-          elsif new_key == 'resource'
+          elsif new_key == 'body'
             new_object[new_key] = IIIF::V3::Service.from_ordered_hash(hsh[key], IIIF::V3::Presentation::Resource)
           elsif hsh[key].kind_of?(Hash)
             new_object[new_key] = IIIF::V3::Service.from_ordered_hash(hsh[key])

--- a/spec/fixtures/v3/manifests/complete_from_spec.json
+++ b/spec/fixtures/v3/manifests/complete_from_spec.json
@@ -176,10 +176,19 @@
       "id": "http://www.example.org/iiif/book1/range/r1",
       "type": "Range",
       "label": "Introduction",
-      "canvases": [
-        "http://www.example.org/iiif/book1/canvas/p1",
-        "http://www.example.org/iiif/book1/canvas/p2",
-        "http://www.example.org/iiif/book1/canvas/p3#xywh=0,0,750,300"
+      "members": [
+        {
+          "id": "http://www.example.org/iiif/book1/canvas/p1",
+          "type": "Canvas"
+        },
+        {
+          "id": "http://www.example.org/iiif/book1/canvas/p2",
+          "type": "Canvas"
+        },
+        {
+          "id": "http://www.example.org/iiif/book1/canvas/p3#xywh=0,0,750,300",
+          "type": "Canvas"
+        }
       ]
     }
   ]

--- a/spec/fixtures/v3/manifests/complete_from_spec.json
+++ b/spec/fixtures/v3/manifests/complete_from_spec.json
@@ -1,4 +1,8 @@
 {
+  "@context": [
+    "http://iiif.io/api/presentation/3/context.json",
+    "http://www.w3.org/ns/anno.jsonld"
+  ],
   "id": "http://www.example.org/iiif/book1/manifest",
   "type": "Manifest",
   "label": "Book 1",
@@ -64,6 +68,7 @@
                     "height": 2000,
                     "width": 1500,
                     "service": {
+                      "@context": "http://iiif.io/api/image/2/context.json",
                       "id": "http://www.example.org/images/book1-page1",
                       "profile": "http://iiif.io/api/image/2/level1.json"
                     }

--- a/spec/fixtures/v3/manifests/complete_from_spec.json
+++ b/spec/fixtures/v3/manifests/complete_from_spec.json
@@ -63,7 +63,7 @@
                   "target": "http://www.example.org/iiif/book1/canvas/p1",
                   "resource": {
                     "id": "http://www.example.org/iiif/book1/res/page1.jpg",
-                    "type": "dctypes:Image",
+                    "type": "Image",
                     "format": "image/jpeg",
                     "height": 2000,
                     "width": 1500,
@@ -98,7 +98,7 @@
                   "motivation": "painting",
                   "resource": {
                     "id": "http://www.example.org/images/book1-page2/full/1500,2000/0/default.jpg",
-                    "type": "dctypes:Image",
+                    "type": "Image",
                     "format": "image/jpeg",
                     "height": 2000,
                     "width": 1500,
@@ -149,7 +149,7 @@
                   "target": "http://www.example.org/iiif/book1/canvas/p3",
                   "resource": {
                     "id": "http://www.example.org/iiif/book1/res/page3.jpg",
-                    "type": "dctypes:Image",
+                    "type": "Image",
                     "format": "image/jpeg",
                     "height": 2000,
                     "width": 1500,

--- a/spec/fixtures/v3/manifests/complete_from_spec.json
+++ b/spec/fixtures/v3/manifests/complete_from_spec.json
@@ -61,7 +61,7 @@
                   "type": "Annotation",
                   "motivation": "painting",
                   "target": "http://www.example.org/iiif/book1/canvas/p1",
-                  "resource": {
+                  "body": {
                     "id": "http://www.example.org/iiif/book1/res/page1.jpg",
                     "type": "Image",
                     "format": "image/jpeg",
@@ -96,7 +96,7 @@
                 {
                   "type": "Annotation",
                   "motivation": "painting",
-                  "resource": {
+                  "body": {
                     "id": "http://www.example.org/images/book1-page2/full/1500,2000/0/default.jpg",
                     "type": "Image",
                     "format": "image/jpeg",
@@ -147,7 +147,7 @@
                   "type": "Annotation",
                   "motivation": "painting",
                   "target": "http://www.example.org/iiif/book1/canvas/p3",
-                  "resource": {
+                  "body": {
                     "id": "http://www.example.org/iiif/book1/res/page3.jpg",
                     "type": "Image",
                     "format": "image/jpeg",

--- a/spec/fixtures/v3/manifests/minimal.json
+++ b/spec/fixtures/v3/manifests/minimal.json
@@ -26,7 +26,7 @@
                   "type": "Annotation",
                   "motivation": "painting",
                   "target": "http://www.example.org/iiif/book1/canvas/p1",
-                  "resource": {
+                  "body": {
                     "id": "http://www.example.org/iiif/book1/res/page1.jpg",
                     "type": "Image",
                     "format": "image/jpeg",

--- a/spec/fixtures/v3/manifests/minimal.json
+++ b/spec/fixtures/v3/manifests/minimal.json
@@ -28,7 +28,7 @@
                   "target": "http://www.example.org/iiif/book1/canvas/p1",
                   "resource": {
                     "id": "http://www.example.org/iiif/book1/res/page1.jpg",
-                    "type": "dctypes:Image",
+                    "type": "Image",
                     "format": "image/jpeg",
                     "height": 2000,
                     "width": 1500,

--- a/spec/fixtures/v3/manifests/minimal.json
+++ b/spec/fixtures/v3/manifests/minimal.json
@@ -1,4 +1,8 @@
 {
+  "@context": [
+    "http://iiif.io/api/presentation/3/context.json",
+    "http://www.w3.org/ns/anno.jsonld"
+  ],
   "type": "Manifest",
   "id": "http://www.example.org/iiif/book1/manifest",
   "label": "Book 1",
@@ -29,6 +33,7 @@
                     "height": 2000,
                     "width": 1500,
                     "service": {
+                      "@context": "http://iiif.io/api/image/2/context.json",
                       "id": "http://www.example.org/images/book1-page1",
                       "profile": "http://iiif.io/api/image/2/level1.json"
                     }

--- a/spec/fixtures/v3/manifests/service_only.json
+++ b/spec/fixtures/v3/manifests/service_only.json
@@ -1,9 +1,13 @@
 {
+  "@context": [
+    "http://iiif.io/api/presentation/3/context.json",
+    "http://www.w3.org/ns/anno.jsonld"
+  ],
   "type": "Manifest",
   "id": "http://www.example.org/iiif/book1/manifest",
   "label": "Book 1",
   "service": {
-    "context": "http://example.org/ns/jsonld/context.json",
+    "@context": "http://example.org/ns/jsonld/context.json",
     "id": "http://example.org/service/example",
     "profile": "http://example.org/docs/example-service.html"
   }

--- a/spec/integration/iiif/v3/presentation/image_resource_spec.rb
+++ b/spec/integration/iiif/v3/presentation/image_resource_spec.rb
@@ -32,7 +32,7 @@ describe IIIF::V3::Presentation::ImageResource do
         # expect(resource['@context']).to eq 'http://iiif.io/api/presentation/2/context.json'
         # @context is only added when we call to_json...
         expect(resource['id']).to eq 'https://libimages.princeton.edu/loris/pudl0001%2F4612422%2F00000001.jp2/full/!200,200/0/default.jpg'
-        expect(resource['type']).to eq 'dctypes:Image'
+        expect(resource['type']).to eq 'Image'
         expect(resource.format).to eq "image/jpeg"
         expect(resource.width).to eq 3047
         expect(resource.height).to eq 7200
@@ -45,7 +45,7 @@ describe IIIF::V3::Presentation::ImageResource do
         resource = described_class.create_image_api_image_resource(opts)
 
         expect(resource['id']).to eq 'https://libimages.princeton.edu/loris/pudl0001%2F4612422%2F00000001.jp2/full/!200,200/0/default.jpg'
-        expect(resource['type']).to eq 'dctypes:Image'
+        expect(resource['type']).to eq 'Image'
         expect(resource.format).to eq "image/jpeg"
         expect(resource.width).to eq 3047
         expect(resource.height).to eq 7200

--- a/spec/integration/iiif/v3/service_spec.rb
+++ b/spec/integration/iiif/v3/service_spec.rb
@@ -40,6 +40,10 @@ describe IIIF::V3::Service do
 
   describe 'self#from_ordered_hash' do
     let(:fixture) { JSON.parse('{
+        "@context": [
+          "http://iiif.io/api/presentation/3/context.json",
+          "http://www.w3.org/ns/anno.jsonld"
+        ],
         "id": "http://example.com/manifest",
         "type": "Manifest",
         "label": "My Manifest",

--- a/spec/unit/iiif/v3/presentation/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/presentation/abstract_resource_spec.rb
@@ -98,11 +98,11 @@ describe IIIF::V3::Presentation::AbstractResource do
   end
 
   describe '#to_ordered_hash' do
-    describe 'does not add the @context' do
+    describe 'adds the @context' do
       before(:each) { subject.delete('@context') }
       it 'by default' do
         expect(subject.has_key?('@context')).to be_falsey
-        expect(subject.to_ordered_hash.has_key?('@context')).to be_falsey
+        expect(subject.to_ordered_hash.has_key?('@context')).to be_truthy
       end
       it 'unless you say not to' do
         expect(subject.has_key?('@context')).to be_falsey

--- a/spec/unit/iiif/v3/presentation/annotation_collection_spec.rb
+++ b/spec/unit/iiif/v3/presentation/annotation_collection_spec.rb
@@ -2,6 +2,10 @@ describe IIIF::V3::Presentation::AnnotationCollection do
 
   let(:fixed_values) do
     {
+      "@context": [
+        "http://iiif.io/api/presentation/3/context.json",
+        "http://www.w3.org/ns/anno.jsonld"
+      ],
       'id' => 'http://www.example.org/iiif/book1/annoColl/transcription',
       'type' => 'AnnotationCollection',
       'label' => 'Diplomatic Transcription',

--- a/spec/unit/iiif/v3/presentation/canvas_spec.rb
+++ b/spec/unit/iiif/v3/presentation/canvas_spec.rb
@@ -2,6 +2,10 @@ describe IIIF::V3::Presentation::Canvas do
 
   let(:fixed_values) do
     {
+      "@context": [
+        "http://iiif.io/api/presentation/3/context.json",
+        "http://www.w3.org/ns/anno.jsonld"
+      ],
       "id" => "http://www.example.org/iiif/book1/canvas/p1",
       "type" => "Canvas",
       "label" => "p. 1",

--- a/spec/unit/iiif/v3/presentation/collection_spec.rb
+++ b/spec/unit/iiif/v3/presentation/collection_spec.rb
@@ -2,6 +2,10 @@ describe IIIF::V3::Presentation::Collection do
 
   let(:fixed_values) do
     {
+      "@context": [
+        "http://iiif.io/api/presentation/3/context.json",
+        "http://www.w3.org/ns/anno.jsonld"
+      ],
       'id' => 'http://example.org/iiif/collection/top',
       'type' => 'Collection',
       'label' => 'Top Level Collection for Example Organization',

--- a/spec/unit/iiif/v3/presentation/image_resource_spec.rb
+++ b/spec/unit/iiif/v3/presentation/image_resource_spec.rb
@@ -1,8 +1,8 @@
 describe IIIF::V3::Presentation::ImageResource do
 
   describe '#initialize' do
-    it 'sets type to dctypes:Image' do
-      expect(subject['type']).to eq 'dctypes:Image'
+    it 'sets type to Image' do
+      expect(subject['type']).to eq 'Image'
     end
   end
 

--- a/spec/unit/iiif/v3/presentation/range_spec.rb
+++ b/spec/unit/iiif/v3/presentation/range_spec.rb
@@ -5,14 +5,27 @@ describe IIIF::V3::Presentation::Range do
       'id' => 'http://www.example.org/iiif/book1/range/r1',
       'type' => 'Range',
       'label' => 'Introduction',
-      'ranges' => [
-        'http://www.example.org/iiif/book1/range/r1-1',
-        'http://www.example.org/iiif/book1/range/r1-2'
-      ],
-      'canvases' => [
-        'http://www.example.org/iiif/book1/canvas/p1',
-        'http://www.example.org/iiif/book1/canvas/p2',
-        'http://www.example.org/iiif/book1/canvas/p3#xywh=0,0,750,300'
+      'members' => [
+        {
+          "id": 'http://www.example.org/iiif/book1/range/r1-1',
+          "type": "Range"
+        },
+        {
+          "id": 'http://www.example.org/iiif/book1/range/r1-2',
+          "type": "Range"
+        },
+        {
+          "id": 'http://www.example.org/iiif/book1/canvas/p1',
+          "type": "Canvas"
+        },
+        {
+          "id": 'http://www.example.org/iiif/book1/canvas/p2',
+          "type": "Canvas"
+        },
+        {
+          "id": 'http://www.example.org/iiif/book1/canvas/p3#xywh=0,0,750,300',
+          "type": "Canvas"
+        }
       ]
     }
   end


### PR DESCRIPTION
Resolves #5:

- [x] add the fake v3 @context:
```
"@context" : [
       "http://www.w3.org/ns/anno.jsonld",
       "http://iiif.io/api/presentation/3/context.json"
   ]
```
- [x] remove the dctypes: prefix from https://github.com/sul-dlss/osullivan/blob/uv-v3/lib/iiif/v3/presentation/image_resource.rb#L10
- [x] Annotation model uses `body` instead of `resource`
- [x] Range model uses `members` instead of `canvases` and `ranges`