### PR TITLE
V3 abstract_resource beef up

### DIFF
--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -158,7 +158,7 @@ module IIIF
             end
           end
         end
-        # thumbnail is Array; each entry is a Hash containing (at least) 'id' and 'type' keys
+        # Thumbnail is Array; each entry is a Hash containing (at least) 'id' and 'type' keys
         if self.has_key?('thumbnail') && self['thumbnail']
           unless self['thumbnail'].all? { |entry| entry.kind_of?(Hash) }
             m = 'thumbnail must be an Array with Hash members'
@@ -172,6 +172,20 @@ module IIIF
             end
           end
         end
+        # NavDate (navigation date)
+        if self.has_key?('nav_date')
+          begin
+            Date.strptime(self['nav_date'], '%Y-%m-%dT%H:%M:%SZ')
+          rescue ArgumentError
+            m = "nav_date must be of form YYYY-MM-DDThh:mm:ssZ"
+            raise IIIF::V3::Presentation::IllegalValueError, m
+          end
+        end
+
+        # TODO: rights - confusing;  Array of hashes? including id which must be a URI?
+        # rights
+
+        # TODO: rendering -  A label and the format of the rendering resource must be supplied
       end
 
       # Options

--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -21,17 +21,21 @@ module IIIF
         %w{ }
       end
 
-      def any_type_keys # these are allowed on all classes
-        %w{ label description thumbnail attribution logo see_also
-        related within }
+      # NOTE: keys associated with a single resource type are not included below in xxx_keys methods:
+      #  those single resource types should include additional keys by overriding xxx_keys as appropriate
+
+      def any_type_keys
+        # values *may* be multivalued
+        # NOTE: for id: "Resources that do not require URIs [for ids] may be assigned blank node identifiers"
+        %w{ label description id attribution logo related rendering see_also within }
       end
 
       def string_only_keys
-        %w{ viewing_hint viewing_direction }
+        %w{ nav_date type format viewing_direction viewing_hint start_canvas }
       end
 
       def array_only_keys
-        %w{ metadata rights }
+        %w{ metadata rights thumbnail first last next prev items }
       end
 
       def abstract_resource_only_keys
@@ -41,12 +45,15 @@ module IIIF
       def hash_only_keys
         %w{ }
       end
+
       def int_only_keys
-        %w{ }
+        %w{ height width total start_index }
       end
+
       def numeric_only_keys
-        %w{ }
+        %w{ duration }
       end
+
       def uri_only_keys
         %w{ }
       end

--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -16,6 +16,11 @@ module IIIF
         %w{ type }
       end
 
+      # subclasses should override prohibited_keys as appropriate, e.g. super + PAGING_PROPERTIES
+      def prohibited_keys
+        %w{ }
+      end
+
       def any_type_keys # these are allowed on all classes
         %w{ label description thumbnail attribution logo see_also
         related within }
@@ -105,6 +110,13 @@ module IIIF
           unless self.has_key?(k)
             m = "A(n) #{k} is required for each #{self.class}"
             raise IIIF::V3::Presentation::MissingRequiredKeyError, m
+          end
+        end
+
+        self.prohibited_keys.each do |k|
+          if self.has_key?(k)
+            m = "#{k} is a prohibited key in #{self.class}"
+            raise IIIF::V3::Presentation::ProhibitedKeyError, m
           end
         end
 

--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -5,7 +5,13 @@ module IIIF
     class AbstractResource
       include IIIF::HashBehaviours
 
-      # Every subclass should override the following methods defining key value types, see Subclasses for how
+      # properties used by content resources only
+      CONTENT_RESOURCE_PROPERTIES = %w{ format height width duration }
+
+      # used by Collection, AnnotationCollection
+      PAGING_PROPERTIES = %w{ first last next prev total start_index }
+
+      # subclasses should override required_keys as appropriate, e.g. super + %w{ id }
       def required_keys
         %w{ type }
       end

--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -144,11 +144,32 @@ module IIIF
             raise IIIF::V3::Presentation::IllegalValueError, m
           end
         end
-        # Metadata is all hashes
-        if self.has_key?('metadata') && self['metadata'].kind_of?(Array)
+        # Metadata is Array; each entry is a Hash containing (only) 'label' and 'value' properties
+        if self.has_key?('metadata') && self['metadata']
           unless self['metadata'].all? { |entry| entry.kind_of?(Hash) }
-            m = 'All entries in the metadata list must be a type of Hash'
+            m = 'metadata must be an Array with Hash members'
             raise IIIF::V3::Presentation::IllegalValueError, m
+          end
+          self['metadata'].each do |entry|
+            md_keys = entry.keys
+            unless md_keys.size == 2 && md_keys.include?('label') && md_keys.include?('value')
+              m = "metadata members must be a Hash of keys 'label' and 'value'"
+              raise IIIF::V3::Presentation::IllegalValueError, m
+            end
+          end
+        end
+        # thumbnail is Array; each entry is a Hash containing (at least) 'id' and 'type' keys
+        if self.has_key?('thumbnail') && self['thumbnail']
+          unless self['thumbnail'].all? { |entry| entry.kind_of?(Hash) }
+            m = 'thumbnail must be an Array with Hash members'
+            raise IIIF::V3::Presentation::IllegalValueError, m
+          end
+          self['thumbnail'].each do |entry|
+            thumb_keys = entry.keys
+            unless thumb_keys.include?('id') && thumb_keys.include?('type')
+              m = 'thumbnail members must be a Hash including keys "id" and "type"'
+              raise IIIF::V3::Presentation::IllegalValueError, m
+            end
           end
         end
       end

--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -311,8 +311,8 @@ module IIIF
       end
 
       def define_methods_for_array_only_keys
-        define_accessor_methods(*array_only_keys) do |key, arg|
-          unless arg.kind_of?(Array)
+        define_accessor_methods(*array_only_keys) do |key, val|
+          unless val.kind_of?(Array)
             m = "#{key} must be an Array."
             raise IIIF::V3::Presentation::IllegalValueError, m
           end
@@ -320,8 +320,8 @@ module IIIF
       end
 
       def define_methods_for_hash_only_keys
-        define_accessor_methods(*hash_only_keys) do |key, arg|
-          unless arg.kind_of?(Hash)
+        define_accessor_methods(*hash_only_keys) do |key, val|
+          unless val.kind_of?(Hash)
             m = "#{key} must be a Hash."
             raise IIIF::V3::Presentation::IllegalValueError, m
           end
@@ -334,8 +334,8 @@ module IIIF
           key = hsh[:key]
           type = hsh[:type]
 
-          define_accessor_methods(key) do |k, arg|
-            unless arg.kind_of?(type)
+          define_accessor_methods(key) do |k, val|
+            unless val.kind_of?(type)
               m = "#{k} must be an #{type}."
               raise IIIF::V3::Presentation::IllegalValueError, m
             end
@@ -344,8 +344,8 @@ module IIIF
       end
 
       def define_methods_for_string_only_keys
-        define_accessor_methods(*string_only_keys) do |key, arg|
-          unless arg.kind_of?(String)
+        define_accessor_methods(*string_only_keys) do |key, val|
+          unless val.kind_of?(String)
             m = "#{key} must be a String."
             raise IIIF::V3::Presentation::IllegalValueError, m
           end
@@ -353,8 +353,8 @@ module IIIF
       end
 
       def define_methods_for_int_only_keys
-        define_accessor_methods(*int_only_keys) do |key, arg|
-          unless arg.kind_of?(Integer) && arg > 0
+        define_accessor_methods(*int_only_keys) do |key, val|
+          unless val.kind_of?(Integer) && val > 0
             m = "#{key} must be a positive Integer."
             raise IIIF::V3::Presentation::IllegalValueError, m
           end
@@ -362,8 +362,8 @@ module IIIF
       end
 
       def define_methods_for_numeric_only_keys
-        define_accessor_methods(*numeric_only_keys) do |key, arg|
-          unless arg.kind_of?(Numeric) && arg > 0
+        define_accessor_methods(*numeric_only_keys) do |key, val|
+          unless val.kind_of?(Numeric) && val > 0
             m = "#{key} must be a positive Integer or Float."
             raise IIIF::V3::Presentation::IllegalValueError, m
           end
@@ -371,8 +371,8 @@ module IIIF
       end
 
       def define_methods_for_uri_only_keys
-        define_accessor_methods(*uri_only_keys) do |key, arg|
-          unless arg.kind_of?(String) && arg =~ URI::regexp
+        define_accessor_methods(*uri_only_keys) do |key, val|
+          unless val.kind_of?(String) && val =~ URI::regexp
             m = "#{key} must be a String containing a URI."
             raise IIIF::V3::Presentation::IllegalValueError, m
           end
@@ -382,14 +382,14 @@ module IIIF
       def define_accessor_methods(*keys, &validation)
         keys.each do |key|
           # Setter
-          define_singleton_method("#{key}=") do |arg|
-            validation.call(key, arg) if block_given?
-            self.send('[]=', key, arg)
+          define_singleton_method("#{key}=") do |val|
+            validation.call(key, val) if block_given?
+            self.send('[]=', key, val)
           end
           if key.camelize(:lower) != key
-            define_singleton_method("#{key.camelize(:lower)}=") do |arg|
-              validation.call(key, arg) if block_given?
-              self.send('[]=', key, arg)
+            define_singleton_method("#{key.camelize(:lower)}=") do |val|
+              validation.call(key, val) if block_given?
+              self.send('[]=', key, val)
             end
           end
           # Getter

--- a/lib/iiif/v3/presentation.rb
+++ b/lib/iiif/v3/presentation.rb
@@ -29,6 +29,7 @@ module IIIF
       ]
 
       class MissingRequiredKeyError < StandardError; end
+      class ProhibitedKeyError < StandardError; end
       class IllegalValueError < StandardError; end
     end
   end

--- a/lib/iiif/v3/presentation/annotation_collection.rb
+++ b/lib/iiif/v3/presentation/annotation_collection.rb
@@ -17,10 +17,6 @@ module IIIF
           super + %w{ content }
         end
 
-        def uri_only_keys
-          super + %w{ first last }
-        end
-
         def initialize(hsh={})
           hsh['type'] = TYPE unless hsh.has_key? 'type'
           super(hsh)

--- a/lib/iiif/v3/presentation/sequence.rb
+++ b/lib/iiif/v3/presentation/sequence.rb
@@ -5,12 +5,8 @@ module IIIF
 
         TYPE = 'Sequence'
 
-        def array_only_keys
-          super + %w{ canvases }
-        end
-
-        def string_only_keys
-          super + %w{ start_canvas }
+        def required_keys
+          super + %w{ items }
         end
 
         def legal_viewing_hint_values

--- a/spec/integration/iiif/v3/abstract_resource_spec.rb
+++ b/spec/integration/iiif/v3/abstract_resource_spec.rb
@@ -69,7 +69,7 @@ describe IIIF::V3::AbstractResource do
             "viewingHint":"paged",
             "startCanvas": "http://www.example.org/iiif/book1/canvas/p2",
 
-            "canvases": [
+            "items": [
               {
                 "id": "http://example.com/canvas",
                 "type": "Canvas",
@@ -128,12 +128,11 @@ describe IIIF::V3::AbstractResource do
         expect(s.class).to be expected_klass
       end
     end
-    it 'turns each member of sequences/canvaes in an instance of Canvas' do
-      expected_klass = IIIF::V3::Presentation::Canvas
+    it 'turns each member of items into an instance of Canvas' do
       parsed = described_class.from_ordered_hash(fixture)
       parsed['sequences'].each do |s|
-        s.canvases.each do |c|
-          expect(c.class).to be expected_klass
+        s.items.each do |c|
+          expect(c.class).to be IIIF::V3::Presentation::Canvas
         end
       end
     end

--- a/spec/unit/iiif/v3/abstract_resource_define_methods_for_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_define_methods_for_spec.rb
@@ -2,19 +2,19 @@ class AbstractResourceSubClass < IIIF::V3::AbstractResource
   TYPE = 'Ignore'
   # need a property here for type of key not already initialized in AbstractResource
   def array_only_keys
-    super + %w{ my_array }
+    super + %w{ array my_array }
   end
   def hash_only_keys
-    super + %w{ my_hash }
+    super + %w{ hash my_hash }
   end
   def int_only_keys
-    super + %w{ my_int }
+    super + %w{ int my_int }
   end
   def numeric_only_keys
-    super + %w{ my_num }
+    super + %w{ num my_num }
   end
   def uri_only_keys
-    super + %w{ my_uri }
+    super + %w{ uri my_uri }
   end
 
   def initialize(hsh={})
@@ -62,6 +62,9 @@ describe AbstractResourceSubClass do
   end
   describe "*define_methods_for_array_only_keys" do
     it_behaves_like 'it has the appropriate methods for array-only keys v3'
+  end
+  describe "*define_methods_for_hash_only_keys" do
+    it_behaves_like 'it has the appropriate methods for hash-only keys v3'
   end
   describe "*define_methods_for_int_only_keys" do
     it_behaves_like 'it has the appropriate methods for integer-only keys v3'

--- a/spec/unit/iiif/v3/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_spec.rb
@@ -71,8 +71,27 @@ describe IIIF::V3::AbstractResource do
       expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
     end
     it 'raises IllegalValueError for metadata entry that is not a Hash' do
-      subject['metadata'] = [{ 'foo' => 'bar' }, 'error', { 'bar' => 'foo' }]
-      exp_err_msg = "All entries in the metadata list must be a type of Hash"
+      subject['metadata'] = ['error']
+      exp_err_msg = "metadata must be an Array with Hash members"
+      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+    end
+    it 'raises IllegalValueError for metadata entry that does not contain exactly "label" and "value"' do
+      subject['metadata'] = [{ 'label' => 'bar', 'value' => 'foo' }]
+      expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+      subject['metadata'] = [{ 'label' => 'bar', 'bar' => 'foo' }]
+      exp_err_msg = "metadata members must be a Hash of keys 'label' and 'value'"
+      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+    end
+    it 'raises IllegalValueError for thumbnail entry that is not a Hash' do
+      subject['thumbnail'] = ['error']
+      exp_err_msg = "thumbnail must be an Array with Hash members"
+      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+    end
+    it 'raises IllegalValueError for thumbnail entry that does not contain "id" and "type"' do
+      subject['thumbnail'] = [{ 'id' => 'bar', 'type' => 'foo', 'random' => 'xxx' }]
+      expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+      subject['thumbnail'] = [{ 'id' => 'bar' }]
+      exp_err_msg = 'thumbnail members must be a Hash including keys "id" and "type"'
       expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
     end
   end

--- a/spec/unit/iiif/v3/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_spec.rb
@@ -113,6 +113,28 @@ describe IIIF::V3::AbstractResource do
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
       end
     end
+    describe 'rights' do
+      #rights - confusing;  Array of hashes? including id which must be a URI?
+      it 'raises IllegalValueError for entry that is not a Hash' do
+        subject['rights'] = ['error']
+        exp_err_msg = "rights must be an Array with Hash members"
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
+      it 'does not raise error for entry with "id" that is URI' do
+        subject['rights'] = [{ 'id' => 'http://example.org/rights', 'format' => 'text/html' }]
+        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+      end
+      it 'raises IllegalValueError for entry with "id" that is not URI' do
+        subject['rights'] = [{ 'id' => 'bar', 'format' => 'text/html' }]
+        exp_err_msg = "id value must be a String containing a URI"
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
+      it 'raises IllegalValueError for entry that does not contain "id"' do
+        subject['rights'] = [{ 'whoops' => 'http://example.org/rights' }]
+        exp_err_msg = 'rights members must be a Hash including "id"'
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
+    end
   end
 
   describe 'A nested object (e.g. self[\'metadata\'])' do

--- a/spec/unit/iiif/v3/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_spec.rb
@@ -78,7 +78,7 @@ describe IIIF::V3::AbstractResource do
       end
       it 'does not raise error for entry that contains exactly "label" and "value"' do
         subject['metadata'] = [{ 'label' => 'bar', 'value' => 'foo' }]
-        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+        expect { subject.validate }.not_to raise_error
       end
       it 'raises IllegalValueError for entry that does not contain exactly "label" and "value"' do
         subject['metadata'] = [{ 'label' => 'bar', 'bar' => 'foo' }]
@@ -94,7 +94,7 @@ describe IIIF::V3::AbstractResource do
       end
       it 'does not raise error for entry with "id" and "type"' do
         subject['thumbnail'] = [{ 'id' => 'bar', 'type' => 'foo', 'random' => 'xxx' }]
-        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+        expect { subject.validate }.not_to raise_error
       end
       it 'raises IllegalValueError for entry that does not contain "id" and "type"' do
         subject['thumbnail'] = [{ 'id' => 'bar' }]
@@ -105,7 +105,7 @@ describe IIIF::V3::AbstractResource do
     describe 'nav_date' do
       it 'does not raise error for value of form YYYY-MM-DDThh:mm:ssZ' do
         subject['nav_date'] = '1991-01-02T13:04:27Z'
-        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+        expect { subject.validate }.not_to raise_error
       end
       it 'raises IllegalValueError for value not of form YYYY-MM-DDThh:mm:ssZ' do
         subject['nav_date'] = '1991-01-02T13:04:27+0500'
@@ -121,7 +121,7 @@ describe IIIF::V3::AbstractResource do
       end
       it 'does not raise error for entry with "id" that is URI' do
         subject['rights'] = [{ 'id' => 'http://example.org/rights', 'format' => 'text/html' }]
-        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+        expect { subject.validate }.not_to raise_error
       end
       it 'raises IllegalValueError for entry with "id" that is not URI' do
         subject['rights'] = [{ 'id' => 'bar', 'format' => 'text/html' }]
@@ -142,7 +142,7 @@ describe IIIF::V3::AbstractResource do
       end
       it 'does not raise error for entry with "label" and "format"' do
         subject['rendering'] = [{ 'label' => 'bar', 'format' => 'foo', 'random' => 'xxx' }]
-        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+        expect { subject.validate }.not_to raise_error
       end
       it 'raises IllegalValueError for entry that does not contain "label" and "format"' do
         subject['rendering'] = [{ 'label' => 'bar' }]

--- a/spec/unit/iiif/v3/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_spec.rb
@@ -114,7 +114,6 @@ describe IIIF::V3::AbstractResource do
       end
     end
     describe 'rights' do
-      #rights - confusing;  Array of hashes? including id which must be a URI?
       it 'raises IllegalValueError for entry that is not a Hash' do
         subject['rights'] = ['error']
         exp_err_msg = "rights must be an Array with Hash members"
@@ -132,6 +131,22 @@ describe IIIF::V3::AbstractResource do
       it 'raises IllegalValueError for entry that does not contain "id"' do
         subject['rights'] = [{ 'whoops' => 'http://example.org/rights' }]
         exp_err_msg = 'rights members must be a Hash including "id"'
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
+    end
+    describe 'rendering' do
+      it 'raises IllegalValueError for entry that is not a Hash' do
+        subject['rendering'] = ['error']
+        exp_err_msg = "rendering must be an Array with Hash members"
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
+      it 'does not raise error for entry with "label" and "format"' do
+        subject['rendering'] = [{ 'label' => 'bar', 'format' => 'foo', 'random' => 'xxx' }]
+        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+      end
+      it 'raises IllegalValueError for entry that does not contain "label" and "format"' do
+        subject['rendering'] = [{ 'label' => 'bar' }]
+        exp_err_msg = 'rendering members must be a Hash including keys "label" and "format"'
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
       end
     end

--- a/spec/unit/iiif/v3/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_spec.rb
@@ -18,6 +18,10 @@ describe IIIF::V3::AbstractResource do
       def required_keys
         super + %w{ id }
       end
+
+      def prohibited_keys
+        super + %w{ verboten }
+      end
     end
   end
   subject do
@@ -50,6 +54,11 @@ describe IIIF::V3::AbstractResource do
     it 'raises MissingRequiredKeyError if required key is missing' do
       subject.required_keys.each { |k| subject.delete(k) }
       expect { subject.validate }.to raise_error IIIF::V3::Presentation::MissingRequiredKeyError
+    end
+    it 'raises ProhibitedKeyError if prohibited key is present' do
+      subject['verboten'] = 666
+      exp_err_msg = "verboten is a prohibited key in #{subject.class}"
+      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::ProhibitedKeyError, exp_err_msg)
     end
     it 'raises IllegalValueError for bad viewing_direction' do
       subject['viewing_direction'] = 'foo'

--- a/spec/unit/iiif/v3/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_spec.rb
@@ -70,29 +70,48 @@ describe IIIF::V3::AbstractResource do
       exp_err_msg = "viewingHint for #{subject.class} must be one of #{subject.legal_viewing_hint_values}"
       expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
     end
-    it 'raises IllegalValueError for metadata entry that is not a Hash' do
-      subject['metadata'] = ['error']
-      exp_err_msg = "metadata must be an Array with Hash members"
-      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+    describe 'metadata' do
+      it 'raises IllegalValueError for entry that is not a Hash' do
+        subject['metadata'] = ['error']
+        exp_err_msg = "metadata must be an Array with Hash members"
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
+      it 'does not raise error for entry that contains exactly "label" and "value"' do
+        subject['metadata'] = [{ 'label' => 'bar', 'value' => 'foo' }]
+        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+      end
+      it 'raises IllegalValueError for entry that does not contain exactly "label" and "value"' do
+        subject['metadata'] = [{ 'label' => 'bar', 'bar' => 'foo' }]
+        exp_err_msg = "metadata members must be a Hash of keys 'label' and 'value'"
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
     end
-    it 'raises IllegalValueError for metadata entry that does not contain exactly "label" and "value"' do
-      subject['metadata'] = [{ 'label' => 'bar', 'value' => 'foo' }]
-      expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
-      subject['metadata'] = [{ 'label' => 'bar', 'bar' => 'foo' }]
-      exp_err_msg = "metadata members must be a Hash of keys 'label' and 'value'"
-      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+    describe 'thumbnail' do
+      it 'raises IllegalValueError for entry that is not a Hash' do
+        subject['thumbnail'] = ['error']
+        exp_err_msg = "thumbnail must be an Array with Hash members"
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
+      it 'does not raise error for entry with "id" and "type"' do
+        subject['thumbnail'] = [{ 'id' => 'bar', 'type' => 'foo', 'random' => 'xxx' }]
+        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+      end
+      it 'raises IllegalValueError for entry that does not contain "id" and "type"' do
+        subject['thumbnail'] = [{ 'id' => 'bar' }]
+        exp_err_msg = 'thumbnail members must be a Hash including keys "id" and "type"'
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
     end
-    it 'raises IllegalValueError for thumbnail entry that is not a Hash' do
-      subject['thumbnail'] = ['error']
-      exp_err_msg = "thumbnail must be an Array with Hash members"
-      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
-    end
-    it 'raises IllegalValueError for thumbnail entry that does not contain "id" and "type"' do
-      subject['thumbnail'] = [{ 'id' => 'bar', 'type' => 'foo', 'random' => 'xxx' }]
-      expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
-      subject['thumbnail'] = [{ 'id' => 'bar' }]
-      exp_err_msg = 'thumbnail members must be a Hash including keys "id" and "type"'
-      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+    describe 'nav_date' do
+      it 'does not raise error for value of form YYYY-MM-DDThh:mm:ssZ' do
+        subject['nav_date'] = '1991-01-02T13:04:27Z'
+        expect { subject.validate }.not_to raise_error(IIIF::V3::Presentation::IllegalValueError)
+      end
+      it 'raises IllegalValueError for value not of form YYYY-MM-DDThh:mm:ssZ' do
+        subject['nav_date'] = '1991-01-02T13:04:27+0500'
+        exp_err_msg = 'nav_date must be of form YYYY-MM-DDThh:mm:ssZ'
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
     end
   end
 

--- a/spec/unit/iiif/v3/presentation/sequence_spec.rb
+++ b/spec/unit/iiif/v3/presentation/sequence_spec.rb
@@ -1,5 +1,11 @@
 describe IIIF::V3::Presentation::Sequence do
 
+  describe '#required_keys' do
+    it 'accumulates from the superclass' do
+      expect(subject.required_keys).to eq %w{ type items }
+    end
+  end
+
   let(:subclass_subject) do
     Class.new(IIIF::V3::Presentation::Sequence) do
       def initialize(hsh={})
@@ -39,7 +45,7 @@ describe IIIF::V3::Presentation::Sequence do
       'within' => 'http://www.example.org/collections/books/',
       # Sequence
       'metadata' => [{'label'=>'Author', 'value'=>'Anne Author'}],
-      'canvases' => [{
+      'items' => [{
         'id' => 'http://www.example.org/iiif/book1/canvas/p1',
         'type' => 'Canvas',
         'label' => 'p. 1',
@@ -63,24 +69,6 @@ describe IIIF::V3::Presentation::Sequence do
     end
   end
 
-  describe '#required_keys' do
-    it 'accumulates from the superclass' do
-      expect(subject.required_keys).to eq %w{ type }
-    end
-  end
-
-  describe '#string_only_keys' do
-    it 'accumulates from the superclass' do
-      expect(subject.string_only_keys).to eq %w{ viewing_hint viewing_direction start_canvas }
-    end
-  end
-
-  describe '#array_only_keys' do
-    it 'accumulates from the superclass' do
-      expect(subject.array_only_keys).to eq %w{ metadata rights canvases }
-    end
-  end
-
   describe "#{described_class}.define_methods_for_array_only_keys" do
     it_behaves_like 'it has the appropriate methods for array-only keys v3'
   end
@@ -96,10 +84,12 @@ describe IIIF::V3::Presentation::Sequence do
   describe '#validate' do
     it 'raises an error if viewing_hint isn\'t an allowable value' do
       subject['viewing_hint'] = 'foo'
+      subject['items'] = [IIIF::V3::Presentation::Canvas.new]
       expect { subject.validate }.to raise_error IIIF::V3::Presentation::IllegalValueError
     end
     it 'raises an error if viewing_directon isn\'t an allowable value' do
       subject['viewing_direction'] = 'foo-to-bar'
+      subject['items'] = [IIIF::V3::Presentation::Canvas.new]
       expect { subject.validate }.to raise_error IIIF::V3::Presentation::IllegalValueError
     end
   end

--- a/spec/unit/iiif/v3/presentation/shared_examples/hash_only_keys.rb
+++ b/spec/unit/iiif/v3/presentation/shared_examples/hash_only_keys.rb
@@ -10,7 +10,7 @@ shared_examples 'it has the appropriate methods for hash-only keys v3' do
       end
       if prop.camelize(:lower) != prop
         it "is aliased as ##{prop.camelize(:lower)}=" do
-          ex = [{'label' => 'XYZ'}]
+          ex = {'label' => 'XYZ'}
           subject.send("#{prop.camelize(:lower)}=", ex)
           expect(subject[prop]).to eq ex
         end


### PR DESCRIPTION
setting up `abstract_resource` to do more heavy lifting for keys/properties that are used by multiple subclasses

I think this is simple enough that one reviewer is enough.