### PR TITLE
v3 abstract_resource: viewing_hint multivalued and can also be a URI

### DIFF
--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -27,11 +27,11 @@ module IIIF
       def any_type_keys
         # values *may* be multivalued
         # NOTE: for id: "Resources that do not require URIs [for ids] may be assigned blank node identifiers"
-        %w{ label description id attribution logo related see_also within }
+        %w{ label description id attribution logo viewing_hint related see_also within }
       end
 
       def string_only_keys
-        %w{ nav_date type format viewing_direction viewing_hint start_canvas }
+        %w{ nav_date type format viewing_direction start_canvas }
       end
 
       def array_only_keys
@@ -138,12 +138,15 @@ module IIIF
             raise IIIF::V3::Presentation::IllegalValueError, m
           end
         end
-        # Viewing Hint values
+        # Viewing Hint can be an Array ("Any resource type may have one or more viewing hints")
         if self.has_key?('viewing_hint')
-          unless self.legal_viewing_hint_values.include?(self['viewing_hint'])
-            m = "viewingHint for #{self.class} must be one of #{self.legal_viewing_hint_values}"
-            raise IIIF::V3::Presentation::IllegalValueError, m
-          end
+          viewing_hint_val = self['viewing_hint']
+          [*viewing_hint_val].each { |vh_val|
+            unless self.legal_viewing_hint_values.include?(vh_val) || (vh_val.kind_of?(String) && vh_val =~ URI::regexp)
+                m = "viewingHint for #{self.class} must be one or more of #{self.legal_viewing_hint_values} or a URI"
+                raise IIIF::V3::Presentation::IllegalValueError, m
+            end
+          }
         end
         # Metadata is Array; each entry is a Hash containing (only) 'label' and 'value' properties
         if self.has_key?('metadata') && self['metadata']
@@ -196,7 +199,7 @@ module IIIF
             validate_uri(entry['id'], 'id') # raises IllegalValueError
           end
         end
-        #  rendering is Array; each entry is a Hash containing 'label' and 'format' keys
+        # rendering is Array; each entry is a Hash containing 'label' and 'format' keys
         if self.has_key?('rendering') && self['rendering']
           unless self['rendering'].all? { |entry| entry.kind_of?(Hash) }
             m = 'rendering must be an Array with Hash members'

--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -213,6 +213,10 @@ module IIIF
             end
           end
         end
+        # startCanvas is a String with a URI value
+        if self.has_key?('start_canvas') && self['start_canvas'].kind_of?(String)
+          validate_uri(self['start_canvas'], 'startCanvas') # raises IllegalValueError
+        end
       end
 
       # Options

--- a/spec/unit/iiif/v3/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_spec.rb
@@ -168,6 +168,13 @@ describe IIIF::V3::AbstractResource do
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
       end
     end
+    describe 'startCanvas' do
+      it 'raises IllegalValueError for entry that is not URI' do
+        subject.startCanvas = 'foo'
+        exp_err_msg = "startCanvas value must be a String containing a URI"
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
+    end
   end
 
   describe 'A nested object (e.g. self[\'metadata\'])' do

--- a/spec/unit/iiif/v3/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_spec.rb
@@ -22,6 +22,10 @@ describe IIIF::V3::AbstractResource do
       def prohibited_keys
         super + %w{ verboten }
       end
+
+      def legal_viewing_hint_values
+        %w{ viewing_hint1 viewing_hint2 }
+      end
     end
   end
   subject do
@@ -65,10 +69,24 @@ describe IIIF::V3::AbstractResource do
       exp_err_msg = "viewingDirection must be one of #{subject.legal_viewing_direction_values}"
       expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
     end
-    it 'raises IllegalValueError for bad viewing_hint' do
-      subject['viewing_hint'] = 'foo'
-      exp_err_msg = "viewingHint for #{subject.class} must be one of #{subject.legal_viewing_hint_values}"
-      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+    describe 'viewing_hint' do
+      it 'can be a uri' do
+        subject['viewing_hint'] = 'https://example.org/viewiing_hint'
+        expect { subject.validate }.not_to raise_error
+      end
+      it 'can be a member of legal_viewing_hint_values' do
+        subject['viewing_hint'] = subject.legal_viewing_hint_values.first
+        expect { subject.validate }.not_to raise_error
+      end
+      it 'raises IllegalValueError for bad viewing_hint' do
+        subject['viewing_hint'] = 'foo'
+        exp_err_msg = "viewingHint for #{subject.class} must be one or more of #{subject.legal_viewing_hint_values} or a URI"
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
+      end
+      it 'can have multiple values' do
+        subject['viewing_hint'] = [subject.legal_viewing_hint_values.first, subject.legal_viewing_hint_values.last]
+        expect { subject.validate }.not_to raise_error
+      end
     end
     describe 'metadata' do
       it 'raises IllegalValueError for entry that is not a Hash' do


### PR DESCRIPTION
from the spec:

      Any resource type may have one or more viewing hints.

      Other values may be given, and if they are, they must be URIs.

This is in the v2 spec as well as the (existing) v3 spec.