### PR TITLE
v3 sequence: improve specificity, validation and tests

### DIFF
--- a/lib/iiif/v3/presentation/sequence.rb
+++ b/lib/iiif/v3/presentation/sequence.rb
@@ -5,12 +5,20 @@ module IIIF
 
         TYPE = 'Sequence'.freeze
 
-        def required_keys
-          super + %w{ items }
-        end
+        # NOTE:  relaxing requirement for items as Universal Viewer currently only accepts canvases
+        #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
+        # def required_keys
+        #   super + %w{ items }
+        # end
 
         def prohibited_keys
           super + CONTENT_RESOURCE_PROPERTIES + PAGING_PROPERTIES + %w{ nav_date content_annotations }
+        end
+
+        # NOTE: allowing 'items' or 'canvases' as Universal Viewer currently only accepts canvases
+        #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
+        def array_only_keys
+          super + %w{ canvases }
         end
 
         def legal_viewing_hint_values
@@ -25,19 +33,32 @@ module IIIF
         def validate
           super
 
-          unless self['items'].size >= 1
-            m = 'The items list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)'
+          # Canvas object list
+          # NOTE: allowing 'items' or 'canvases' as Universal Viewer currently only accepts canvases
+          #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
+          unless (self['items'] && self['items'].any?) ||
+              (self['canvases'] && self['canvases'].any?)
+            m = 'The (items or canvases) list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)'
             raise IIIF::V3::Presentation::MissingRequiredKeyError, m
           end
-
-          unless self['items'].all? { |entry| entry.instance_of?(IIIF::V3::Presentation::Canvas) }
-            m = 'All entries in the items list must be a IIIF::V3::Presentation::Canvas'
-            raise IIIF::V3::Presentation::IllegalValueError, m
-          end
+          validate_canvas_list(self['items']) if self['items']
+          validate_canvas_list(self['canvases']) if self['canvases']
 
           # TODO: startCanvas: A link from a Sequence or Range to a Canvas that is contained within it
 
           # TODO: All external Sequences must have a dereference-able http(s) URI
+        end
+
+        def validate_canvas_list(canvas_array)
+          unless canvas_array.size >= 1
+            m = 'The (items or canvases) list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)'
+            raise IIIF::V3::Presentation::MissingRequiredKeyError, m
+          end
+
+          unless canvas_array.all? { |entry| entry.instance_of?(IIIF::V3::Presentation::Canvas) }
+            m = 'All entries in the (items or canvases) list must be a IIIF::V3::Presentation::Canvas'
+            raise IIIF::V3::Presentation::IllegalValueError, m
+          end
         end
       end
     end

--- a/lib/iiif/v3/presentation/sequence.rb
+++ b/lib/iiif/v3/presentation/sequence.rb
@@ -3,10 +3,14 @@ module IIIF
     module Presentation
       class Sequence < IIIF::V3::AbstractResource
 
-        TYPE = 'Sequence'
+        TYPE = 'Sequence'.freeze
 
         def required_keys
           super + %w{ items }
+        end
+
+        def prohibited_keys
+          super + CONTENT_RESOURCE_PROPERTIES + PAGING_PROPERTIES + %w{ nav_date content_annotations }
         end
 
         def legal_viewing_hint_values
@@ -20,8 +24,20 @@ module IIIF
 
         def validate
           super
-          # TODO: Must be at least one canvas
-          # TODO: All members of canvases must be a kind of Canvas
+
+          unless self['items'].size >= 1
+            m = 'The items list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)'
+            raise IIIF::V3::Presentation::MissingRequiredKeyError, m
+          end
+
+          unless self['items'].all? { |entry| entry.instance_of?(IIIF::V3::Presentation::Canvas) }
+            m = 'All entries in the items list must be a IIIF::V3::Presentation::Canvas'
+            raise IIIF::V3::Presentation::IllegalValueError, m
+          end
+
+          # TODO: startCanvas: A link from a Sequence or Range to a Canvas that is contained within it
+
+          # TODO: All external Sequences must have a dereference-able http(s) URI
         end
       end
     end

--- a/spec/unit/iiif/v3/presentation/sequence_spec.rb
+++ b/spec/unit/iiif/v3/presentation/sequence_spec.rb
@@ -1,62 +1,35 @@
 describe IIIF::V3::Presentation::Sequence do
 
   describe '#required_keys' do
-    it 'accumulates from the superclass' do
-      expect(subject.required_keys).to eq %w{ type items }
-    end
-  end
-
-  let(:subclass_subject) do
-    Class.new(IIIF::V3::Presentation::Sequence) do
-      def initialize(hsh={})
-        hsh = { 'type' => 'a:SubClass' }
-        super(hsh)
+    %w{ type items }.each do |k|
+      it k do
+        expect(subject.required_keys).to include(k)
       end
     end
   end
 
-  let(:fixed_values) do
-    {
-      'type' => 'Sequence',
-      'id' => 'http://example.com/prefix/sequence/456',
-      'label' => 'Book 1',
-      'description' => 'A longer description of this example book. It should give some real information.',
-      'thumbnail' => {
-        'id' => 'http://www.example.org/images/book1-page1/full/80,100/0/default.jpg',
-        'service'=> {
-          '@context' => 'http://iiif.io/api/image/2/context.json',
-          'id' => 'http://www.example.org/images/book1-page1',
-          'profile' => 'http://iiif.io/api/image/2/level1.json'
+  describe '#prohibited_keys' do
+    it 'contains the expected key names' do
+      keys = described_class::CONTENT_RESOURCE_PROPERTIES +
+        described_class::PAGING_PROPERTIES +
+        %w{
+          nav_date
+          content_annotations
         }
-      },
-      'attribution' => 'Provided by Example Organization',
-      'rights' => [{'id' => 'http://www.example.org/license.html'}],
-      'logo' => 'http://www.example.org/logos/institution1.jpg',
-      'see_also' => 'http://www.example.org/library/catalog/book1.xml',
-      'service' => {
-        '@context' => 'http://example.org/ns/jsonld/context.json',
-        'id' =>  'http://example.org/service/example',
-        'profile' => 'http://example.org/docs/example-service.html'
-      },
-      'related' => {
-        'id' => 'http://www.example.org/videos/video-book1.mpg',
-        'format' => 'video/mpeg'
-      },
-      'within' => 'http://www.example.org/collections/books/',
-      # Sequence
-      'metadata' => [{'label'=>'Author', 'value'=>'Anne Author'}],
-      'items' => [{
-        'id' => 'http://www.example.org/iiif/book1/canvas/p1',
-        'type' => 'Canvas',
-        'label' => 'p. 1',
-        'height' => 1000,
-        'width' => 750,
-        'content'=>  []
-      }],
-      'viewing_hint' => 'paged',
-      'start_canvas' => 'http://www.example.org/iiif/book1/canvas/p2',
-      'viewing_direction' => 'right-to-left',
-    }
+      expect(subject.prohibited_keys).to include(*keys)
+    end
+  end
+
+  describe '#array_only_keys' do
+    it 'items' do
+      expect(subject.array_only_keys).to include('items')
+    end
+  end
+
+  describe '#legal_viewing_hint_values' do
+    it 'contains the expected values' do
+      expect(subject.legal_viewing_hint_values).to contain_exactly('individuals', 'paged', 'continuous', 'auto-advance')
+    end
   end
 
   describe '#initialize' do
@@ -64,35 +37,140 @@ describe IIIF::V3::Presentation::Sequence do
       expect(subject['type']).to eq 'Sequence'
     end
     it 'allows subclasses to override type' do
-      sub = subclass_subject.new
+      subclass = Class.new(described_class) do
+        def initialize(hsh={})
+          hsh = { 'type' => 'a:SubClass' }
+          super(hsh)
+        end
+      end
+      sub = subclass.new
       expect(sub['type']).to eq 'a:SubClass'
     end
   end
 
-  describe "#{described_class}.define_methods_for_array_only_keys" do
-    it_behaves_like 'it has the appropriate methods for array-only keys v3'
-  end
-
-  describe "#{described_class}.define_methods_for_string_only_keys" do
-    it_behaves_like 'it has the appropriate methods for string-only keys v3'
-  end
-
-  describe "#{described_class}.define_methods_for_any_type_keys" do
-    it_behaves_like 'it has the appropriate methods for any-type keys v3'
-  end
-
   describe '#validate' do
-    it 'raises an error if viewing_hint isn\'t an allowable value' do
-      subject['viewing_hint'] = 'foo'
-      subject['items'] = [IIIF::V3::Presentation::Canvas.new]
-      expect { subject.validate }.to raise_error IIIF::V3::Presentation::IllegalValueError
+     it 'raises MissingRequiredKeyError for items as empty Array' do
+      subject['items'] = []
+      exp_err_msg = "The items list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)"
+      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, exp_err_msg)
     end
-    it 'raises an error if viewing_directon isn\'t an allowable value' do
-      subject['viewing_direction'] = 'foo-to-bar'
-      subject['items'] = [IIIF::V3::Presentation::Canvas.new]
-      expect { subject.validate }.to raise_error IIIF::V3::Presentation::IllegalValueError
+    it 'raises IllegalValueError for items entry that is not a Canvas' do
+      subject['items'] = [IIIF::V3::Presentation::Canvas.new, IIIF::V3::Presentation::AnnotationPage.new]
+      exp_err_msg = "All entries in the items list must be a IIIF::V3::Presentation::Canvas"
+      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
     end
   end
 
+  describe 'realistic examples' do
+    let!(:canvas_object) { IIIF::V3::Presentation::Canvas.new({
+      "id" => "https://example.org/abc666/iiif3/canvas/0001",
+      "label" => "p. 1",
+      "height" => 7579,
+      "width" => 10108,
+      "content" => []
+      })}
+    describe 'minimal sequence' do
+      let!(:sequence_object) { described_class.new({
+        "items" => [canvas_object]
+      })}
+      it 'validates' do
+        expect{sequence_object.validate}.not_to raise_error
+      end
+      it 'has expected required values' do
+        expect(sequence_object.type).to eq 'Sequence'
+        expect(sequence_object.items.size).to be 1
+        expect(sequence_object.items.first).to eq canvas_object
+      end
+    end
+    
+    describe 'example from Stanford purl' do
+      let!(:sequence_object) {IIIF::V3::Presentation::Sequence.new({
+        "id" => "https://example.org/abc666#sequence-1",
+        "label" => "Current order",
+        "type" => "Sequence",
+        "items" => [canvas_object]
+      })}
+      it 'validates' do
+        expect{sequence_object.validate}.not_to raise_error
+      end
+      it 'has expected required values' do
+        expect(sequence_object.type).to eq 'Sequence'
+        expect(sequence_object.items.size).to be 1
+        expect(sequence_object.items.first).to eq canvas_object
+      end
+      it 'has expected string values' do
+        expect(sequence_object.id).to eq "https://example.org/abc666#sequence-1"
+        expect(sequence_object.label).to eq "Current order"
+      end
+    end
 
+    describe 'example from http://prezi3.iiif.io/api/presentation/3.0' do
+      let!(:sequence_object) { described_class.new({
+        "id" => "http://example.org/iiif/book1/sequence/normal",
+        "label" => {"en" => "Current Page Order"},
+        "viewingDirection" => "left-to-right",
+        "viewingHint" => ["paged"],
+        "startCanvas" => canvas_object.id,
+        "items" => [canvas_object]
+      })}
+      it 'validates' do
+        expect{sequence_object.validate}.not_to raise_error
+      end
+      it 'has expected required values' do
+        expect(sequence_object.type).to eq 'Sequence'
+        expect(sequence_object.items.size).to be 1
+        expect(sequence_object.items.first).to eq canvas_object
+      end
+      it 'has expected string values' do
+        expect(sequence_object.id).to eq "http://example.org/iiif/book1/sequence/normal"
+        expect(sequence_object.viewingDirection).to eq "left-to-right"
+        expect(sequence_object.startCanvas).to eq "https://example.org/abc666/iiif3/canvas/0001"
+      end
+      it 'has expected additional content' do
+        expect(sequence_object.viewingHint).to eq ["paged"]
+        expect(sequence_object.label).to eq ({"en" => "Current Page Order"})
+      end
+    end
+
+    describe 'another example' do
+      let!(:sequence_object) { described_class.new({
+        "id" => "http://example.com/prefix/sequence/456",
+        'label' => 'Book 1',
+        'description' => 'A longer description of this example book. It should give some real information.',
+        'thumbnail' => [{
+          'id' => 'http://www.example.org/images/book1-page1/full/80,100/0/default.jpg',
+          'type' => 'Image',
+          'service'=> {
+            '@context' => 'http://iiif.io/api/image/2/context.json',
+            'id' => 'http://www.example.org/images/book1-page1',
+            'profile' => 'http://iiif.io/api/image/2/level1.json'
+          }
+        }],
+        'attribution' => 'Provided by Example Organization',
+        'rights' => [{'id' => 'http://www.example.org/license.html'}],
+        'logo' => 'http://www.example.org/logos/institution1.jpg',
+        'see_also' => 'http://www.example.org/library/catalog/book1.xml',
+        'service' => {
+          '@context' => 'http://example.org/ns/jsonld/context.json',
+          'id' =>  'http://example.org/service/example',
+          'profile' => 'http://example.org/docs/example-service.html'
+        },
+        'related' => {
+          'id' => 'http://www.example.org/videos/video-book1.mpg',
+          'format' => 'video/mpeg'
+        },
+        'within' => 'http://www.example.org/collections/books/',
+        # Sequence
+        'metadata' => [{'label'=>'Author', 'value'=>'Anne Author'}],
+        "items" => [canvas_object],
+        'start_canvas' => 'http://www.example.org/iiif/book1/canvas/p2',
+        "viewingDirection" => "left-to-right",
+        "viewingHint" => ["paged"],
+        "startCanvas" => canvas_object.id,
+      })}
+      it 'validates' do
+        expect{sequence_object.validate}.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/unit/iiif/v3/presentation/sequence_spec.rb
+++ b/spec/unit/iiif/v3/presentation/sequence_spec.rb
@@ -128,6 +128,26 @@ describe IIIF::V3::Presentation::Sequence do
         expect(sequence_object.id).to eq seq_id
         expect(sequence_object.label).to eq "Current order"
       end
+      describe 'with viewingDirection' do
+        let(:sequence_vd) {
+          sequence_object.viewingDirection = 'left-to-right'
+          sequence_object
+        }
+        it 'validates' do
+          expect{sequence_vd.validate}.not_to raise_error
+        end
+        it 'has expected required values' do
+          expect(sequence_vd.type).to eq 'Sequence'
+          expect(sequence_vd.canvases.size).to be 1
+          expect(sequence_vd.canvases.first).to eq canvas_object
+        end
+        it 'has expected string values' do
+          expect(sequence_vd.id).to eq seq_id
+          expect(sequence_vd.label).to eq "Current order"
+          expect(sequence_vd.viewing_direction).to eq 'left-to-right'
+          expect(sequence_vd.viewingDirection).to eq 'left-to-right'
+        end
+      end
     end
 
     describe 'example from http://prezi3.iiif.io/api/presentation/3.0' do


### PR DESCRIPTION
connects to #6 

This is now merge-able. These changes should not adversely affect purl code (as there are tests validating sequence building specifically akin to our purl code).  I'm not sure this is so complex as to require multiple reviewers, so if you're comfortable with it, feel free to merge it.

I have relaxed the v3 documented spec requirements that won't work with UV. I did this as a separate commit.

The IIIF v3 requirement to use 'items' is documented in #27 and in sul-dlss/purl#167.