### PR TITLE
Update for prezi3 changes

### DIFF
--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -27,7 +27,7 @@ module IIIF
       def any_type_keys
         # values *may* be multivalued
         # NOTE: for id: "Resources that do not require URIs [for ids] may be assigned blank node identifiers"
-        %w{ description id logo viewing_hint related see_also within }
+        %w{ id logo viewing_hint related see_also within }
       end
 
       def string_only_keys
@@ -35,15 +35,11 @@ module IIIF
       end
 
       def array_only_keys
-        %w{ metadata rights thumbnail rendering first last next prev items }
-      end
-
-      def abstract_resource_only_keys
-        [ { key: 'service', type: IIIF::V3::Presentation::Service } ]
+        %w{ metadata rights thumbnail rendering first last next prev items service }
       end
 
       def hash_only_keys
-        %w{ label requiredStatement }
+        %w{ label requiredStatement summary }
       end
 
       def int_only_keys
@@ -84,7 +80,6 @@ module IIIF
         self.define_methods_for_hash_only_keys
         self.define_methods_for_int_only_keys
         self.define_methods_for_numeric_only_keys
-        self.define_methods_for_abstract_resource_only_keys
         self.define_methods_for_uri_only_keys
         self.snakeize_keys
       end
@@ -422,21 +417,6 @@ module IIIF
           unless val.kind_of?(Hash)
             m = "#{key} must be a Hash."
             raise IIIF::V3::Presentation::IllegalValueError, m
-          end
-        end
-      end
-
-      def define_methods_for_abstract_resource_only_keys
-        # values in this case: an array of hashes with { key: 'k', type: Class }
-        abstract_resource_only_keys.each do |hsh|
-          key = hsh[:key]
-          type = hsh[:type]
-
-          define_accessor_methods(key) do |k, val|
-            unless val.kind_of?(type)
-              m = "#{k} must be an #{type}."
-              raise IIIF::V3::Presentation::IllegalValueError, m
-            end
           end
         end
       end

--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -27,7 +27,7 @@ module IIIF
       def any_type_keys
         # values *may* be multivalued
         # NOTE: for id: "Resources that do not require URIs [for ids] may be assigned blank node identifiers"
-        %w{ description id attribution logo viewing_hint related see_also within }
+        %w{ description id logo viewing_hint related see_also within }
       end
 
       def string_only_keys
@@ -43,7 +43,7 @@ module IIIF
       end
 
       def hash_only_keys
-        %w{ label }
+        %w{ label requiredStatement }
       end
 
       def int_only_keys

--- a/lib/iiif/v3/abstract_resource.rb
+++ b/lib/iiif/v3/abstract_resource.rb
@@ -27,7 +27,7 @@ module IIIF
       def any_type_keys
         # values *may* be multivalued
         # NOTE: for id: "Resources that do not require URIs [for ids] may be assigned blank node identifiers"
-        %w{ label description id attribution logo viewing_hint related see_also within }
+        %w{ description id attribution logo viewing_hint related see_also within }
       end
 
       def string_only_keys
@@ -43,7 +43,7 @@ module IIIF
       end
 
       def hash_only_keys
-        %w{ }
+        %w{ label }
       end
 
       def int_only_keys

--- a/lib/iiif/v3/presentation/annotation.rb
+++ b/lib/iiif/v3/presentation/annotation.rb
@@ -59,14 +59,6 @@ module IIIF
               m = "when #{self.class} body is a kind of #{img_res_class_str}, ImageResource id must be an http(s) URI"
               raise IIIF::V3::Presentation::IllegalValueError, m
             end
-
-            body_service = *body_resource['service']
-            body_service_context = *body_resource['service']['@context']
-            expected_context = IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_CONTEXT
-            unless body_service && body_service_context && body_service_context.include?(expected_context)
-              m = "when #{self.class} body is a kind of #{img_res_class_str}, ImageResource's service @context must include #{expected_context}"
-              raise IIIF::V3::Presentation::IllegalValueError, m
-            end
           end
 
           if self.has_key?('time_mode')

--- a/lib/iiif/v3/presentation/image_resource.rb
+++ b/lib/iiif/v3/presentation/image_resource.rb
@@ -74,22 +74,23 @@ module IIIF
             resource.format = format
             resource.width = width.nil? ? remote_info['width'] : width
             resource.height = height.nil? ? remote_info['height'] : height
-            resource.service = Service.new
+            resource_service = Service.new
             if copy_info
-              resource.service.merge!(remote_info)
-              resource.service['id'] ||= resource.service.delete('@id')
+              resource_service.merge!(remote_info)
+              resource_service['id'] ||= resource_service.delete('@id')
             else
-              resource.service['id'] = service_id
+              resource_service['id'] = service_id
               if profile.nil?
                 if remote_info['profile'].kind_of?(Array)
-                  resource.service['profile'] = remote_info['profile'][0]
+                  resource_service['profile'] = remote_info['profile'][0]
                 else
-                  resource.service['profile'] = remote_info['profile']
+                  resource_service['profile'] = remote_info['profile']
                 end
               else
-                resource.service['profile'] = profile
+                resource_service['profile'] = profile
               end
             end
+            resource.service = [resource_service]
             return resource
           end
 

--- a/lib/iiif/v3/presentation/image_resource.rb
+++ b/lib/iiif/v3/presentation/image_resource.rb
@@ -14,7 +14,6 @@ module IIIF
 
         class << self
           IMAGE_API_DEFAULT_PARAMS = '/full/!200,200/0/default.jpg'.freeze
-          IMAGE_API_CONTEXT = 'http://iiif.io/api/image/2/context.json'.freeze
           DEFAULT_FORMAT = 'image/jpeg'.freeze
           # Create a new ImageResource that includes a IIIF Image API Service
           # See http://iiif.io/api/presentation/2.0/#image-resources
@@ -80,7 +79,6 @@ module IIIF
               resource.service.merge!(remote_info)
               resource.service['id'] ||= resource.service.delete('@id')
             else
-              resource.service['@context'] = IMAGE_API_CONTEXT
               resource.service['id'] = service_id
               if profile.nil?
                 if remote_info['profile'].kind_of?(Array)

--- a/lib/iiif/v3/presentation/manifest.rb
+++ b/lib/iiif/v3/presentation/manifest.rb
@@ -44,16 +44,12 @@ module IIIF
             raise IIIF::V3::Presentation::IllegalValueError, err_msg
           end
 
-          # Sequence object list
-          # NOTE: allowing 'items' or 'sequences' as Universal Viewer currently only accepts sequences
-          #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
-          unless (self['items'] && self['items'].any?) ||
-            (self['sequences'] && self['sequences'].any?)
-            m = 'The (items or sequences) list must have at least one entry (and it must be a IIIF::V3::Presentation::Sequence)'
+          # Items object list
+          unless self&.[]('items')&.any?
+            m = 'The items list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)'
             raise IIIF::V3::Presentation::MissingRequiredKeyError, m
           end
-          validate_sequence_list(self['items']) if self['items']
-          validate_sequence_list(self['sequences']) if self['sequences']
+          validate_items_list(self['items']) if self['items']
 
           # TODO: when embedding a sequence without any extensions within a manifest, the sequence must not have the @context field.
 
@@ -69,32 +65,15 @@ module IIIF
 
         # NOTE: allowing 'items' or 'sequences' as Universal Viewer currently only accepts sequences
         #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
-        def validate_sequence_list(sequence_array)
-          unless sequence_array.size >= 1
-            m = 'The (items or sequences) list must have at least one entry (and it must be a IIIF::V3::Presentation::Sequence)'
+        def validate_items_list(items_array)
+          unless items_array.size >= 1
+            m = 'The items list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)'
             raise IIIF::V3::Presentation::MissingRequiredKeyError, m
           end
 
-          unless sequence_array.all? { |entry| entry.instance_of?(IIIF::V3::Presentation::Sequence) }
-            m = 'All entries in the (items or sequences) list must be a IIIF::V3::Presentation::Sequence'
+          unless items_array.all? { |entry| entry.instance_of?(IIIF::V3::Presentation::Canvas) }
+            m = 'All entries in the items list must be a IIIF::V3::Presentation::Canvas'
             raise IIIF::V3::Presentation::IllegalValueError, m
-          end
-
-          default_sequence = sequence_array.first
-          # NOTE: allowing 'items' or 'canvases' as Universal Viewer currently only accepts canvases
-          #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
-          canvas_array = default_sequence['items'] || default_sequence['canvases']
-          unless canvas_array && canvas_array.size >= 1 &&
-            canvas_array.all? { |entry| entry.instance_of?(IIIF::V3::Presentation::Canvas) }
-            m = 'The default Sequence (the first entry of (items or sequences)) must be written out in full within the Manifest file'
-            raise IIIF::V3::Presentation::IllegalValueError, m
-          end
-
-          if sequence_array.size > 1
-            unless sequence_array.all? { |entry| entry['label'] }
-              m = 'If there are multiple Sequences in a manifest then they must each have at least one label'
-              raise IIIF::V3::Presentation::IllegalValueError, m
-            end
           end
         end
       end

--- a/lib/iiif/v3/presentation/service.rb
+++ b/lib/iiif/v3/presentation/service.rb
@@ -5,7 +5,7 @@ module IIIF
       class Service < AbstractResource
 
         # constants included here for convenience
-        IIIF_IMAGE_V2_CONTEXT = 'http://iiif.io/api/image/2/context.json'.freeze
+        IIIF_IMAGE_V2_TYPE = 'ImageService2'.freeze
         IIIF_IMAGE_V2_LEVEL1_PROFILE = 'http://iiif.io/api/image/2/level1.json'.freeze
         IIIF_AUTHENTICATION_V1_LOGIN_PROFILE = 'http://iiif.io/api/auth/1/login'.freeze
         IIIF_AUTHENTICATION_V1_TOKEN_PROFILE = 'http://iiif.io/api/auth/1/token'.freeze
@@ -30,17 +30,17 @@ module IIIF
 
         def validate
           super
-          if IIIF_IMAGE_V2_CONTEXT == self['@context']
-            unless self.has_key?('@id')
-              m = "@id is required for IIIF::V3::Presentation::Service with @context #{IIIF_IMAGE_V2_CONTEXT}"
+          if IIIF_IMAGE_V2_TYPE == self['type'] || IIIF_IMAGE_V2_TYPE == self['@type']
+            unless self.has_key?('id') || self.has_key?('@id')
+              m = "id or @id values are required for IIIF::V3::Presentation::Service with type or @type #{IIIF_IMAGE_V2_TYPE}"
               raise IIIF::V3::Presentation::MissingRequiredKeyError, m
             end
-            if self.has_key?('id') && (self['@id'] != self['id'])
-              m = "id and @id values must match for IIIF::V3::Presentation::Service with @context #{IIIF_IMAGE_V2_CONTEXT}"
+            if self.has_key?('id') && self.has_key?('@id') && (self['@id'] != self['id'])
+              m = "id and @id values must match for IIIF::V3::Presentation::Service with type or @type #{IIIF_IMAGE_V2_TYPE}"
               raise IIIF::V3::Presentation::IllegalValueError, m
             end
             unless self.has_key?('profile')
-              m = "profile is required for IIIF::V3::Presentation::Service with @context #{IIIF_IMAGE_V2_CONTEXT}"
+              m = "profile should be present for IIIF::V3::Presentation::Service with type or @type #{IIIF_IMAGE_V2_TYPE}"
               raise IIIF::V3::Presentation::MissingRequiredKeyError, m
             end
           end

--- a/spec/fixtures/v3/manifests/complete_from_spec.json
+++ b/spec/fixtures/v3/manifests/complete_from_spec.json
@@ -5,7 +5,7 @@
   ],
   "id": "http://www.example.org/iiif/book1/manifest",
   "type": "Manifest",
-  "label": "Book 1",
+  "label": { "en": [ "Book 1" ] },
   "metadata": [
     {
       "label": "Author",

--- a/spec/integration/iiif/v3/abstract_resource_spec.rb
+++ b/spec/integration/iiif/v3/abstract_resource_spec.rb
@@ -9,26 +9,26 @@ describe IIIF::V3::AbstractResource do
   describe 'self.parse' do
     it 'works from a file' do
       s = described_class.parse(manifest_from_spec_path)
-      expect(s['label']).to eq 'Book 1'
+      expect(s['label']['en']).to include 'Book 1'
     end
     it 'works from a string of JSON' do
       file = File.open(manifest_from_spec_path, 'rb')
       json_string = file.read
       file.close
       s = described_class.parse(json_string)
-      expect(s['label']).to eq 'Book 1'
+      expect(s['label']['en']).to include 'Book 1'
     end
     describe 'works from a hash' do
       it 'plain old' do
         h = JSON.parse(IO.read(manifest_from_spec_path))
         s = described_class.parse(h)
-        expect(s['label']).to eq 'Book 1'
+        expect(s['label']['en']).to include 'Book 1'
       end
       it 'IIIF::OrderedHash' do
         h = JSON.parse(IO.read(manifest_from_spec_path))
         oh = IIIF::OrderedHash[h]
         s = described_class.parse(oh)
-        expect(s['label']).to eq 'Book 1'
+        expect(s['label']['en']).to include 'Book 1'
       end
     end
     it 'turns camels to snakes' do

--- a/spec/integration/iiif/v3/abstract_resource_spec.rb
+++ b/spec/integration/iiif/v3/abstract_resource_spec.rb
@@ -62,28 +62,16 @@ describe IIIF::V3::AbstractResource do
         },
         "items": [
           {
-            "id":"http://www.example.org/iiif/book1/sequence/normal",
-            "type": "Sequence",
-            "label": "Current Page Order",
-
-            "viewingDirection":"left-to-right",
-            "viewingHint":"paged",
-            "startCanvas": "http://www.example.org/iiif/book1/canvas/p2",
-
-            "items": [
+            "id": "http://example.com/canvas",
+            "type": "Canvas",
+            "width": 10,
+            "height": 20,
+            "label": "My Canvas",
+            "content": [
               {
-                "id": "http://example.com/canvas",
-                "type": "Canvas",
-                "width": 10,
-                "height": 20,
-                "label": "My Canvas",
-                "content": [
-                  {
-                    "id": "http://example.com/content",
-                    "type": "AnnotationPage",
-                    "motivation": "painting"
-                  }
-                ]
+                "id": "http://example.com/content",
+                "type": "AnnotationPage",
+                "motivation": "painting"
               }
             ]
           }
@@ -125,7 +113,7 @@ describe IIIF::V3::AbstractResource do
     it 'turns each member of "items" into an instance of Sequence' do
       parsed = described_class.from_ordered_hash(fixture)
       parsed['items'].each do |s|
-        expect(s.class).to be IIIF::V3::Presentation::Sequence
+        expect(s.class).to be IIIF::V3::Presentation::Canvas
       end
     end
     it 'turns each member of sequences/items into an instance of Canvas' do

--- a/spec/integration/iiif/v3/presentation/image_resource_spec.rb
+++ b/spec/integration/iiif/v3/presentation/image_resource_spec.rb
@@ -29,14 +29,11 @@ describe IIIF::V3::Presentation::ImageResource do
       it 'when copy_info is false' do
         opts = { service_id: valid_service_id }
         resource = described_class.create_image_api_image_resource(opts)
-        # expect(resource['@context']).to eq 'http://iiif.io/api/presentation/2/context.json'
-        # @context is only added when we call to_json...
         expect(resource['id']).to eq 'https://libimages.princeton.edu/loris/pudl0001%2F4612422%2F00000001.jp2/full/!200,200/0/default.jpg'
         expect(resource['type']).to eq 'Image'
         expect(resource.format).to eq "image/jpeg"
         expect(resource.width).to eq 3047
         expect(resource.height).to eq 7200
-        expect(resource.service['@context']).to eq 'http://iiif.io/api/image/2/context.json'
         expect(resource.service['id']).to eq 'https://libimages.princeton.edu/loris/pudl0001%2F4612422%2F00000001.jp2'
         expect(resource.service['profile']).to eq 'http://iiif.io/api/image/2/level2.json'
       end
@@ -49,7 +46,6 @@ describe IIIF::V3::Presentation::ImageResource do
         expect(resource.format).to eq "image/jpeg"
         expect(resource.width).to eq 3047
         expect(resource.height).to eq 7200
-        expect(resource.service['@context']).to eq 'http://iiif.io/api/image/2/context.json'
         expect(resource.service['profile']).to eq [
           'http://iiif.io/api/image/2/level2.json',
           {

--- a/spec/integration/iiif/v3/presentation/image_resource_spec.rb
+++ b/spec/integration/iiif/v3/presentation/image_resource_spec.rb
@@ -34,8 +34,8 @@ describe IIIF::V3::Presentation::ImageResource do
         expect(resource.format).to eq "image/jpeg"
         expect(resource.width).to eq 3047
         expect(resource.height).to eq 7200
-        expect(resource.service['id']).to eq 'https://libimages.princeton.edu/loris/pudl0001%2F4612422%2F00000001.jp2'
-        expect(resource.service['profile']).to eq 'http://iiif.io/api/image/2/level2.json'
+        expect(resource.service.first['id']).to eq 'https://libimages.princeton.edu/loris/pudl0001%2F4612422%2F00000001.jp2'
+        expect(resource.service.first['profile']).to eq 'http://iiif.io/api/image/2/level2.json'
       end
       it 'copies over all teh infos (when copy_info is true)' do
         opts = { service_id: valid_service_id, copy_info: true }
@@ -46,7 +46,7 @@ describe IIIF::V3::Presentation::ImageResource do
         expect(resource.format).to eq "image/jpeg"
         expect(resource.width).to eq 3047
         expect(resource.height).to eq 7200
-        expect(resource.service['profile']).to eq [
+        expect(resource.service.first['profile']).to eq [
           'http://iiif.io/api/image/2/level2.json',
           {
             'supports' => [
@@ -57,11 +57,11 @@ describe IIIF::V3::Presentation::ImageResource do
             'formats'=>['jpg', 'png', 'gif', 'webp']
           }
         ]
-        expect(resource.service['tiles']).to eq [ {
+        expect(resource.service.first['tiles']).to eq [ {
           'width' =>  1024,
           'scaleFactors' =>  [ 1, 2, 4, 8, 16, 32 ]
         } ]
-        expect(resource.service['sizes']).to eq [
+        expect(resource.service.first['sizes']).to eq [
           {'width' => 96, 'height' =>  225 },
           {'width' => 191, 'height' =>  450 },
           {'width' => 381, 'height' =>  900 },
@@ -69,8 +69,8 @@ describe IIIF::V3::Presentation::ImageResource do
           {'width' => 1524, 'height' => 3600 },
           {'width' => 3047, 'height' =>  7200 }
         ]
-        expect(resource.service['id']).to eq 'https://libimages.princeton.edu/loris/pudl0001%2F4612422%2F00000001.jp2'
-        expect(resource.service).not_to have_key('@id')
+        expect(resource.service.first['id']).to eq 'https://libimages.princeton.edu/loris/pudl0001%2F4612422%2F00000001.jp2'
+        expect(resource.service.first).not_to have_key('@id')
       end
     end
 
@@ -97,7 +97,7 @@ describe IIIF::V3::Presentation::ImageResource do
         profile = 'http://iiif.io/api/image/2/level1.json'
         opts = { service_id: valid_service_id, profile: profile}
         resource = described_class.create_image_api_image_resource(opts)
-        expect(resource.service['profile']).to eq profile
+        expect(resource.service.first['profile']).to eq profile
       end
     end
 

--- a/spec/unit/iiif/presentation/manifest_spec.rb
+++ b/spec/unit/iiif/presentation/manifest_spec.rb
@@ -14,7 +14,7 @@ describe IIIF::Presentation::Manifest do
       'type' => 'a:SubClass',
       'id' => 'http://example.com/prefix/manifest/123',
       'context' => IIIF::Presentation::CONTEXT,
-      'label' => 'Book 1',
+      'label' => {'en' => ['Book 1']},
       'description' => 'A longer description of this example book. It should give some real information.',
       'thumbnail' => {
         '@id' => 'http://www.example.org/images/book1-page1/full/80,100/0/default.jpg',

--- a/spec/unit/iiif/v3/abstract_resource_define_methods_for_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_define_methods_for_spec.rb
@@ -25,9 +25,6 @@ end
 
 describe AbstractResourceSubClass do
 
-  describe '*define_methods_for_abstract_resource_only_keys' do
-    it_behaves_like 'it has the appropriate methods for abstract_resource_only_keys v3'
-  end
   describe "*define_methods_for_any_type_keys" do
     # shared_example expects fixed_values;  these are roughly based on Stanford purl code
     # (see https://github.com/sul-dlss/purl/blob/master/app/models/iiif3_presentation_manifest.rb)

--- a/spec/unit/iiif/v3/abstract_resource_spec.rb
+++ b/spec/unit/iiif/v3/abstract_resource_spec.rb
@@ -50,7 +50,7 @@ describe IIIF::V3::AbstractResource do
     it 'can take any old hash' do
       hsh = JSON.parse(IO.read(manifest_from_spec_path))
       new_instance = abstract_resource_subclass.new(hsh)
-      expect(new_instance['label']).to eq 'Book 1'
+      expect(new_instance['label']['en']).to include 'Book 1'
     end
   end
 

--- a/spec/unit/iiif/v3/presentation/annotation_spec.rb
+++ b/spec/unit/iiif/v3/presentation/annotation_spec.rb
@@ -4,7 +4,6 @@ describe IIIF::V3::Presentation::Annotation do
   let(:content_type) { 'dctypes:Text' }
   let(:mimetype) { 'application/tei+xml' }
   let(:image_2_api_service) { IIIF::V3::Presentation::Service.new({
-      '@context' => IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_CONTEXT,
       'id' => content_id,
       '@id' => content_id,
       'profile' => IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_LEVEL1_PROFILE
@@ -148,28 +147,6 @@ describe IIIF::V3::Presentation::Annotation do
         img_resource_without_id['id'] = 'ftp://example.com/somewhere'
         img_body_anno.body = img_resource_without_id
         expect { img_body_anno.validate }.to raise_error IIIF::V3::Presentation::IllegalValueError, http_uri_err_msg
-      end
-
-      let(:service_context_err_msg) {
-        "when #{described_class} body is a kind of IIIF::V3::Presentation::ImageResource, ImageResource's service @context must include http://iiif.io/api/image/2/context.json"
-      }
-      it 'raises IllegalValueError if no @context field in ImageResource service' do
-        img_content_resource['service']['@context'] = nil
-        img_body_anno.body = img_content_resource
-        expect { img_body_anno.validate }.to raise_error IIIF::V3::Presentation::IllegalValueError, service_context_err_msg
-      end
-      it 'raises IllegalValueError if @context in ImageResource service doesn\'t include reference to IIIF Image API context doc' do
-        img_content_resource['service']['@context'] = 'http://example.com/context.json'
-        img_body_anno.body = img_content_resource
-        expect { img_body_anno.validate }.to raise_error IIIF::V3::Presentation::IllegalValueError, service_context_err_msg
-        img_content_resource['service']['@context'] = ['http://example.com/context.json', 'http://example.com/context2.json']
-        img_body_anno.body = img_content_resource
-        expect { img_body_anno.validate }.to raise_error IIIF::V3::Presentation::IllegalValueError, service_context_err_msg
-      end
-      it 'does not raise error if @context in ImageResource service includes reference to IIIF Image API context doc' do
-        img_content_resource['service']['@context'] = ['http://example.com/context.json', IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_CONTEXT]
-        img_body_anno.body = img_content_resource
-        expect { img_body_anno.validate }.not_to raise_error
       end
     end
   end

--- a/spec/unit/iiif/v3/presentation/canvas_spec.rb
+++ b/spec/unit/iiif/v3/presentation/canvas_spec.rb
@@ -131,7 +131,7 @@ describe IIIF::V3::Presentation::Canvas do
     let(:canvas_id) { 'http://example.org/iiif/book1/canvas/c1' }
     let(:minimal_canvas_object) { described_class.new({
       "id" => canvas_id,
-      'label' => "so minimal it's not here",
+      'label' => {"en" => ["so minimal it's not here"]},
       'height' => 1000,
       'width' => 1000
     })}
@@ -146,7 +146,7 @@ describe IIIF::V3::Presentation::Canvas do
       it 'has expected required values' do
         expect(minimal_canvas_object.type).to eq described_class::TYPE
         expect(minimal_canvas_object.id).to eq canvas_id
-        expect(minimal_canvas_object.label).to eq "so minimal it's not here"
+        expect(minimal_canvas_object.label['en']).to include "so minimal it's not here"
         expect(minimal_canvas_object.height).to eq 1000
         expect(minimal_canvas_object.width).to eq 1000
       end
@@ -180,7 +180,7 @@ describe IIIF::V3::Presentation::Canvas do
         let(:canvas_object) {
           c = described_class.new
           c['id'] = canvas_id
-          c.label = 'label'
+          c.label = {'en' => ['label']}
           c.content << anno_page
           c
         }
@@ -191,7 +191,7 @@ describe IIIF::V3::Presentation::Canvas do
           it 'has expected required values' do
             expect(canvas_object.type).to eq described_class::TYPE
             expect(canvas_object.id).to eq canvas_id
-            expect(canvas_object.label).to eq "label"
+            expect(canvas_object.label['en']).to include "label"
           end
           it 'has expected additional values' do
             expect(canvas_object.content).to eq [anno_page]
@@ -209,7 +209,7 @@ describe IIIF::V3::Presentation::Canvas do
           it 'has expected required values' do
             expect(img_canvas.type).to eq described_class::TYPE
             expect(img_canvas.id).to eq canvas_id
-            expect(img_canvas.label).to eq "label"
+            expect(img_canvas.label['en']).to include "label"
             expect(img_canvas.height).to eq 666
             expect(img_canvas.width).to eq 888
           end
@@ -223,7 +223,7 @@ describe IIIF::V3::Presentation::Canvas do
         describe 'without extent info' do
           let(:file_object) { described_class.new({
             "id" => "https://example.org/bd742gh0511/iiif3/canvas/bd742gh0511_1",
-            "label" => "File 1",
+            "label" => {"en" => ["File 1"]},
             "content" => [anno_page]
             })}
           it 'validates' do
@@ -236,7 +236,7 @@ describe IIIF::V3::Presentation::Canvas do
         describe 'without extent info' do
           let(:image_object) { described_class.new({
             "id" => "https://example.org/yv090xk3108/iiif3/canvas/yv090xk3108_1",
-            "label" => "image",
+            "label" => {"en" => ["image"]},
             "content" => [anno_page]
             })}
           it 'validates' do
@@ -246,7 +246,7 @@ describe IIIF::V3::Presentation::Canvas do
         describe 'with extent given' do
           let(:image_object) { described_class.new({
             "id" => "https://example.org/yy816tv6021/iiif3/canvas/yy816tv6021_3",
-            "label" => "Image of media (1 of 2)",
+            "label" => {"en" => ["Image of media (1 of 2)"]},
             "height" => 3456,
             "width" => 5184,
             "content" => [anno_page]
@@ -261,7 +261,7 @@ describe IIIF::V3::Presentation::Canvas do
         describe 'without duration' do
           let(:canvas_for_audio) { described_class.new({
             "id" => "https://example.org/xk681bt2506/iiif3/canvas/xk681bt2506_1",
-            "label" => "Audio file 1",
+            "label" => {"en" => ["Audio file 1"]},
             "content" => [anno_page]
             })}
           it 'validates' do

--- a/spec/unit/iiif/v3/presentation/canvas_spec.rb
+++ b/spec/unit/iiif/v3/presentation/canvas_spec.rb
@@ -272,7 +272,9 @@ describe IIIF::V3::Presentation::Canvas do
           let(:canvas_for_audio) { described_class.new({
             "id" => "http://tomcrane.github.io/scratch/manifests/3/canvas/2",
             "label" => "Track 2",
-            "description" => "foo",
+            'summary' => {
+              'en' => ['foo']
+            },
             "duration" => 45,
             "content" => [anno_page]
             })}
@@ -282,8 +284,8 @@ describe IIIF::V3::Presentation::Canvas do
           it 'duration' do
             expect(canvas_for_audio.duration).to eq 45
           end
-          it 'description' do
-            expect(canvas_for_audio.description).to eq 'foo'
+          it 'summary' do
+            expect(canvas_for_audio.summary['en'].first).to eq 'foo'
           end
         end
       end

--- a/spec/unit/iiif/v3/presentation/image_resource_spec.rb
+++ b/spec/unit/iiif/v3/presentation/image_resource_spec.rb
@@ -106,7 +106,6 @@ describe IIIF::V3::Presentation::ImageResource do
             expect(img_service_obj.id).to eq img_id
             expect(img_service_obj['@id']).to eq img_id
             expect(img_service_obj.profile).to eq IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_LEVEL1_PROFILE
-            expect(img_service_obj['@context']).to eq IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_CONTEXT
             expect(img_service_obj.service.class).to eq Array
             expect(img_service_obj.service.size).to eq 1
 

--- a/spec/unit/iiif/v3/presentation/image_resource_spec.rb
+++ b/spec/unit/iiif/v3/presentation/image_resource_spec.rb
@@ -27,7 +27,7 @@ describe IIIF::V3::Presentation::ImageResource do
           thumb['type'] = 'Image'
           thumb['id'] = thumb_id
           thumb.format = img_mimetype
-          thumb.service = image_v2_service
+          thumb.service = [image_v2_service]
           thumb
         }
         it 'validates' do
@@ -39,7 +39,7 @@ describe IIIF::V3::Presentation::ImageResource do
         end
         it 'has expected additional values' do
           expect(thumb_object.format).to eq img_mimetype
-          expect(thumb_object.service).to eq image_v2_service
+          expect(thumb_object.service.first).to eq image_v2_service
         end
       end
       describe 'full size per purl code' do
@@ -50,7 +50,7 @@ describe IIIF::V3::Presentation::ImageResource do
           img.format = img_mimetype
           img.height = height
           img.width = width
-          img.service = image_v2_service
+          img.service = [image_v2_service]
           img
         }
         describe 'world visible' do
@@ -65,16 +65,15 @@ describe IIIF::V3::Presentation::ImageResource do
             expect(image_object.format).to eq img_mimetype
             expect(image_object.height).to eq height
             expect(image_object.width).to eq width
-            expect(image_object.service).to eq image_v2_service
+            expect(image_object.service.first).to eq image_v2_service
           end
           it 'has expected service value' do
-            img_service_obj = image_object.service
+            img_service_obj = image_object.service.first
             expect(img_service_obj.class).to eq IIIF::V3::Presentation::Service
             expect(img_service_obj.keys.size).to eq 4
             expect(img_service_obj.id).to eq img_id
             expect(img_service_obj['@id']).to eq img_id
             expect(img_service_obj.profile).to eq IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_LEVEL1_PROFILE
-            expect(img_service_obj['@context']).to eq IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_CONTEXT
           end
         end
         describe 'requires login' do
@@ -93,14 +92,14 @@ describe IIIF::V3::Presentation::ImageResource do
           }
           let(:image_object_w_login) {
             img = image_object
-            img.service['service'] = [login_service]
+            img.service.first['service'] = [login_service]
             img
           }
           it 'validates' do
             expect{image_object_w_login.validate}.not_to raise_error
           end
           it 'has expected service value' do
-            img_service_obj = image_object_w_login.service
+            img_service_obj = image_object_w_login.service.first
             expect(img_service_obj.class).to eq IIIF::V3::Presentation::Service
             expect(img_service_obj.keys.size).to eq 5
             expect(img_service_obj.id).to eq img_id

--- a/spec/unit/iiif/v3/presentation/manifest_spec.rb
+++ b/spec/unit/iiif/v3/presentation/manifest_spec.rb
@@ -65,7 +65,7 @@ describe IIIF::V3::Presentation::Manifest do
 
   describe '#validate' do
     it 'raises an IllegalValueError if id is not http' do
-      subject.label = 'Book 1'
+      subject.label = {'en' => ['Book 1']}
       subject['id'] = 'ftp://www.example.org'
       subject['items'] = [IIIF::V3::Presentation::Sequence.new]
       exp_err_msg = "id must be an http(s) URI for #{described_class}"
@@ -78,26 +78,26 @@ describe IIIF::V3::Presentation::Manifest do
 
     it 'raises MissingRequiredKeyError if no items or sequences key' do
       subject['id'] = manifest_id
-      subject.label = 'Book 1'
+      subject.label = {'en' => ['Book 1']}
       expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, seq_list_err)
     end
     describe 'items' do
       it 'raises MissingRequiredKeyError for items entry without values' do
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         subject['items'] = []
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, seq_list_err)
       end
       it 'raises IllegalValueError for items entry that is not a Sequence' do
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         subject['items'] = [IIIF::V3::Presentation::Sequence.new, IIIF::V3::Presentation::Canvas.new]
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, seq_entry_err)
       end
       describe 'raises IllegalValueError for default Sequence that is not written out' do
         it 'Sequence has "items"' do
           subject['id'] = manifest_id
-          subject.label = 'Book 1'
+          subject.label = {'en' => ['Book 1']}
           seq = IIIF::V3::Presentation::Sequence.new
           seq['items'] = []
           subject['items'] = [seq]
@@ -107,7 +107,7 @@ describe IIIF::V3::Presentation::Manifest do
         #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
         it 'Sequence has "canvases"' do
           subject['id'] = manifest_id
-          subject.label = 'Book 1'
+          subject.label = {'en' => ['Book 1']}
           seq = IIIF::V3::Presentation::Sequence.new
           seq['canvases'] = []
           subject['items'] = [seq]
@@ -119,7 +119,7 @@ describe IIIF::V3::Presentation::Manifest do
         seq['items'] = [IIIF::V3::Presentation::Canvas.new]
         subject['items'] = [seq]
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         expect { subject.validate }.not_to raise_error
       end
       it 'raises no error for Sequence with populated "canvases"' do
@@ -127,16 +127,16 @@ describe IIIF::V3::Presentation::Manifest do
         seq['canvases'] = [IIIF::V3::Presentation::Canvas.new]
         subject['items'] = [seq]
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         expect { subject.validate }.not_to raise_error
       end
       it 'raises IllegalValueError for Sequences without "label" if there are multiple Sequences' do
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         seq1 = IIIF::V3::Presentation::Sequence.new
         seq1['items'] = [IIIF::V3::Presentation::Canvas.new]
         seq2 = IIIF::V3::Presentation::Sequence.new
-        seq2['label'] = 'label2'
+        seq2['label'] = {'en' => ['label2']}
         subject['items'] = [seq1, seq2]
         exp_err_msg = 'If there are multiple Sequences in a manifest then they must each have at least one label'
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
@@ -145,20 +145,20 @@ describe IIIF::V3::Presentation::Manifest do
     describe 'sequences' do
       it 'raises MissingRequiredKeyError for sequences entry without values' do
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         subject['sequences'] = []
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, seq_list_err)
       end
       it 'raises IllegalValueError for sequences entry that is not a Sequence' do
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         subject['sequences'] = [IIIF::V3::Presentation::Sequence.new, IIIF::V3::Presentation::Canvas.new]
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, seq_entry_err)
       end
       describe 'raises IllegalValueError for default Sequence that is not written out' do
         it 'Sequence has "items"' do
           subject['id'] = manifest_id
-          subject.label = 'Book 1'
+          subject.label = {'en' => ['Book 1']}
           seq = IIIF::V3::Presentation::Sequence.new
           seq['items'] = []
           subject['sequences'] = [seq]
@@ -168,7 +168,7 @@ describe IIIF::V3::Presentation::Manifest do
         #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
         it 'Sequence has "canvases"' do
           subject['id'] = manifest_id
-          subject.label = 'Book 1'
+          subject.label = {'en' => ['Book 1']}
           seq = IIIF::V3::Presentation::Sequence.new
           seq['canvases'] = []
           subject['sequences'] = [seq]
@@ -180,7 +180,7 @@ describe IIIF::V3::Presentation::Manifest do
         seq['items'] = [IIIF::V3::Presentation::Canvas.new]
         subject['sequences'] = [seq]
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         expect { subject.validate }.not_to raise_error
       end
       it 'raises no error for Sequence with populated "canvases"' do
@@ -188,23 +188,23 @@ describe IIIF::V3::Presentation::Manifest do
         seq['canvases'] = [IIIF::V3::Presentation::Canvas.new]
         subject['sequences'] = [seq]
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         expect { subject.validate }.not_to raise_error
       end
       it 'raises IllegalValueError for Sequences without "label" if there are multiple Sequences' do
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         seq1 = IIIF::V3::Presentation::Sequence.new
         seq1['items'] = [IIIF::V3::Presentation::Canvas.new]
         seq2 = IIIF::V3::Presentation::Sequence.new
-        seq2['label'] = 'label2'
+        seq2['label'] = {'en' => ['label2']}
         subject['sequences'] = [seq1, seq2]
         exp_err_msg = 'If there are multiple Sequences in a manifest then they must each have at least one label'
         expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
       end
       it 'raises no error for single Sequences without "label"' do
         subject['id'] = manifest_id
-        subject.label = 'Book 1'
+        subject.label = {'en' => ['Book 1']}
         seq = IIIF::V3::Presentation::Sequence.new
         seq['items'] = [IIIF::V3::Presentation::Canvas.new]
         subject['sequences'] = [seq]
@@ -214,7 +214,7 @@ describe IIIF::V3::Presentation::Manifest do
 
     it 'raises IllegalValueError for structures entry that is not a Range' do
       subject['id'] = manifest_id
-      subject.label = 'Book 1'
+      subject.label = {'en' => ['Book 1']}
       seq = IIIF::V3::Presentation::Sequence.new
       seq['items'] = [IIIF::V3::Presentation::Canvas.new]
       subject['items'] = [seq]
@@ -224,7 +224,7 @@ describe IIIF::V3::Presentation::Manifest do
     end
     it 'raises no error when structures entry is a Range' do
       subject['id'] = manifest_id
-      subject.label = 'Book 1'
+      subject.label = {'en' => ['Book 1']}
       seq = IIIF::V3::Presentation::Sequence.new
       seq['items'] = [IIIF::V3::Presentation::Canvas.new]
       subject['items'] = [seq]
@@ -236,14 +236,14 @@ describe IIIF::V3::Presentation::Manifest do
   describe 'realistic examples' do
     let!(:canvas_object) { IIIF::V3::Presentation::Canvas.new({
       "id" => "https://example.org/abc666/iiif3/canvas/0001",
-      "label" => "image",
+      "label" => {'en' => ['image']},
       "height" => 7579,
       "width" => 10108,
       "content" => []
     })}
     let!(:default_sequence_object) {IIIF::V3::Presentation::Sequence.new({
       "id" => "https://example.org/abc666#sequence-1",
-      "label" => "Current order",
+      "label" => {'en' => ['Current order']},
       "items" => [canvas_object]
     })}
     describe 'realistic(?) minimal manifest' do
@@ -253,7 +253,7 @@ describe IIIF::V3::Presentation::Manifest do
           "http://iiif.io/api/presentation/3/context.json"
         ],
         "id" => "https://example.org/abc666/iiif3/manifest",
-        "label" => "blah",
+        "label" => {"en" => ["blah"]},
         "attribution" => "bleah",
         "description" => "blargh",
         "items" => [default_sequence_object]
@@ -264,7 +264,7 @@ describe IIIF::V3::Presentation::Manifest do
       it 'has expected required values' do
         expect(manifest_object.type).to eq 'Manifest'
         expect(manifest_object.id).to eq "https://example.org/abc666/iiif3/manifest"
-        expect(manifest_object.label).to eq "blah"
+        expect(manifest_object.label['en']).to include "blah"
         expect(manifest_object.items.size).to be 1
         expect(manifest_object.items.first).to eq default_sequence_object
       end
@@ -298,7 +298,7 @@ describe IIIF::V3::Presentation::Manifest do
         })}
       let!(:manifest_object) { described_class.new({
         "id" => "https://example.org/abc666/iiif3/manifest",
-        "label" => "blah",
+        "label" => {"en" => ["blah"]},
         "attribution" => "bleah",
         "description" => "blargh",
         "sequences" => [default_sequence_object],
@@ -333,7 +333,7 @@ describe IIIF::V3::Presentation::Manifest do
       it 'has expected required values' do
         expect(manifest_object.type).to eq 'Manifest'
         expect(manifest_object.id).to eq "https://example.org/abc666/iiif3/manifest"
-        expect(manifest_object.label).to eq "blah"
+        expect(manifest_object.label['en']).to include "blah"
         # NOTE:  using sequences as Universal Viewer currently only accepts sequences
         #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
         expect(manifest_object.sequences.size).to be 1
@@ -354,7 +354,7 @@ describe IIIF::V3::Presentation::Manifest do
         let!(:seq_object) {
           s = IIIF::V3::Presentation::Sequence.new({
           'id' => 'https://example.org/abc666#sequence-1',
-          'label' => 'Current order'
+          "label" => {"en" => ["Current order"]},
           })
           s.viewingDirection = 'left-to-right'
           s.canvases << canvas_object
@@ -363,7 +363,7 @@ describe IIIF::V3::Presentation::Manifest do
         let!(:manifest_data) {
           {
             "id" => "https://example.org/abc666/iiif3/manifest",
-            "label" => "blah",
+            "label" => {"en" => ["blah"]},
             "attribution" => "bleah",
             "logo" => {
               "id" => "https://example.org/logo/full/400,/0/default.jpg",
@@ -393,7 +393,7 @@ describe IIIF::V3::Presentation::Manifest do
         it 'has expected required values' do
           expect(manifest_object.type).to eq 'Manifest'
           expect(manifest_object.id).to eq "https://example.org/abc666/iiif3/manifest"
-          expect(manifest_object.label).to eq "blah"
+          expect(manifest_object.label['en']).to include "blah"
           # NOTE:  using sequences as Universal Viewer currently only accepts sequences
           #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
           expect(manifest_object.sequences.size).to be 1
@@ -414,7 +414,7 @@ describe IIIF::V3::Presentation::Manifest do
     describe 'example from http://prezi3.iiif.io/api/presentation/3.0' do
       let!(:range_object) { IIIF::V3::Presentation::Range.new({
         "id" => "http://example.org/iiif/book1/range/top",
-        "label" => "home, home on the",
+        "label" => {"en" => ["home, home on the"]},
         "viewingHint" => ["top"]
         })
       }

--- a/spec/unit/iiif/v3/presentation/manifest_spec.rb
+++ b/spec/unit/iiif/v3/presentation/manifest_spec.rb
@@ -72,142 +72,31 @@ describe IIIF::V3::Presentation::Manifest do
       expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
     end
 
-    let(:seq_list_err) { 'The (items or sequences) list must have at least one entry (and it must be a IIIF::V3::Presentation::Sequence)' }
-    let(:seq_entry_err) { 'All entries in the (items or sequences) list must be a IIIF::V3::Presentation::Sequence' }
-    let(:def_seq_err) { 'The default Sequence (the first entry of (items or sequences)) must be written out in full within the Manifest file' }
+    let(:item_list_err) { 'The items list must have at least one entry (and it must be a IIIF::V3::Presentation::Canvas)' }
+    let(:item_entry_err) { 'All entries in the items list must be a IIIF::V3::Presentation::Canvas' }
 
     it 'raises MissingRequiredKeyError if no items or sequences key' do
       subject['id'] = manifest_id
       subject.label = {'en' => ['Book 1']}
-      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, seq_list_err)
+      expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, item_list_err)
     end
     describe 'items' do
       it 'raises MissingRequiredKeyError for items entry without values' do
         subject['id'] = manifest_id
         subject.label = {'en' => ['Book 1']}
         subject['items'] = []
-        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, seq_list_err)
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, item_list_err)
       end
       it 'raises IllegalValueError for items entry that is not a Sequence' do
         subject['id'] = manifest_id
         subject.label = {'en' => ['Book 1']}
         subject['items'] = [IIIF::V3::Presentation::Sequence.new, IIIF::V3::Presentation::Canvas.new]
-        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, seq_entry_err)
+        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, item_entry_err)
       end
-      describe 'raises IllegalValueError for default Sequence that is not written out' do
-        it 'Sequence has "items"' do
-          subject['id'] = manifest_id
-          subject.label = {'en' => ['Book 1']}
-          seq = IIIF::V3::Presentation::Sequence.new
-          seq['items'] = []
-          subject['items'] = [seq]
-          expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, def_seq_err)
-        end
-        # NOTE:  also allowing canvases as Universal Viewer currently only accepts canvases
-        #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
-        it 'Sequence has "canvases"' do
-          subject['id'] = manifest_id
-          subject.label = {'en' => ['Book 1']}
-          seq = IIIF::V3::Presentation::Sequence.new
-          seq['canvases'] = []
-          subject['items'] = [seq]
-          expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, def_seq_err)
-        end
-      end
-      it 'raises no error for Sequence with populated "items"' do
-        seq = IIIF::V3::Presentation::Sequence.new
-        seq['items'] = [IIIF::V3::Presentation::Canvas.new]
-        subject['items'] = [seq]
+      it 'raises no error items populated with canvases' do
+        subject['items'] = [IIIF::V3::Presentation::Canvas.new]
         subject['id'] = manifest_id
         subject.label = {'en' => ['Book 1']}
-        expect { subject.validate }.not_to raise_error
-      end
-      it 'raises no error for Sequence with populated "canvases"' do
-        seq = IIIF::V3::Presentation::Sequence.new
-        seq['canvases'] = [IIIF::V3::Presentation::Canvas.new]
-        subject['items'] = [seq]
-        subject['id'] = manifest_id
-        subject.label = {'en' => ['Book 1']}
-        expect { subject.validate }.not_to raise_error
-      end
-      it 'raises IllegalValueError for Sequences without "label" if there are multiple Sequences' do
-        subject['id'] = manifest_id
-        subject.label = {'en' => ['Book 1']}
-        seq1 = IIIF::V3::Presentation::Sequence.new
-        seq1['items'] = [IIIF::V3::Presentation::Canvas.new]
-        seq2 = IIIF::V3::Presentation::Sequence.new
-        seq2['label'] = {'en' => ['label2']}
-        subject['items'] = [seq1, seq2]
-        exp_err_msg = 'If there are multiple Sequences in a manifest then they must each have at least one label'
-        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
-      end
-    end
-    describe 'sequences' do
-      it 'raises MissingRequiredKeyError for sequences entry without values' do
-        subject['id'] = manifest_id
-        subject.label = {'en' => ['Book 1']}
-        subject['sequences'] = []
-        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, seq_list_err)
-      end
-      it 'raises IllegalValueError for sequences entry that is not a Sequence' do
-        subject['id'] = manifest_id
-        subject.label = {'en' => ['Book 1']}
-        subject['sequences'] = [IIIF::V3::Presentation::Sequence.new, IIIF::V3::Presentation::Canvas.new]
-        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, seq_entry_err)
-      end
-      describe 'raises IllegalValueError for default Sequence that is not written out' do
-        it 'Sequence has "items"' do
-          subject['id'] = manifest_id
-          subject.label = {'en' => ['Book 1']}
-          seq = IIIF::V3::Presentation::Sequence.new
-          seq['items'] = []
-          subject['sequences'] = [seq]
-          expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, def_seq_err)
-        end
-        # NOTE:  also allowing canvases as Universal Viewer currently only accepts canvases
-        #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
-        it 'Sequence has "canvases"' do
-          subject['id'] = manifest_id
-          subject.label = {'en' => ['Book 1']}
-          seq = IIIF::V3::Presentation::Sequence.new
-          seq['canvases'] = []
-          subject['sequences'] = [seq]
-          expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, def_seq_err)
-        end
-      end
-      it 'raises no error for Sequence with populated "items"' do
-        seq = IIIF::V3::Presentation::Sequence.new
-        seq['items'] = [IIIF::V3::Presentation::Canvas.new]
-        subject['sequences'] = [seq]
-        subject['id'] = manifest_id
-        subject.label = {'en' => ['Book 1']}
-        expect { subject.validate }.not_to raise_error
-      end
-      it 'raises no error for Sequence with populated "canvases"' do
-        seq = IIIF::V3::Presentation::Sequence.new
-        seq['canvases'] = [IIIF::V3::Presentation::Canvas.new]
-        subject['sequences'] = [seq]
-        subject['id'] = manifest_id
-        subject.label = {'en' => ['Book 1']}
-        expect { subject.validate }.not_to raise_error
-      end
-      it 'raises IllegalValueError for Sequences without "label" if there are multiple Sequences' do
-        subject['id'] = manifest_id
-        subject.label = {'en' => ['Book 1']}
-        seq1 = IIIF::V3::Presentation::Sequence.new
-        seq1['items'] = [IIIF::V3::Presentation::Canvas.new]
-        seq2 = IIIF::V3::Presentation::Sequence.new
-        seq2['label'] = {'en' => ['label2']}
-        subject['sequences'] = [seq1, seq2]
-        exp_err_msg = 'If there are multiple Sequences in a manifest then they must each have at least one label'
-        expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
-      end
-      it 'raises no error for single Sequences without "label"' do
-        subject['id'] = manifest_id
-        subject.label = {'en' => ['Book 1']}
-        seq = IIIF::V3::Presentation::Sequence.new
-        seq['items'] = [IIIF::V3::Presentation::Canvas.new]
-        subject['sequences'] = [seq]
         expect { subject.validate }.not_to raise_error
       end
     end
@@ -215,9 +104,7 @@ describe IIIF::V3::Presentation::Manifest do
     it 'raises IllegalValueError for structures entry that is not a Range' do
       subject['id'] = manifest_id
       subject.label = {'en' => ['Book 1']}
-      seq = IIIF::V3::Presentation::Sequence.new
-      seq['items'] = [IIIF::V3::Presentation::Canvas.new]
-      subject['items'] = [seq]
+      subject['items'] = [IIIF::V3::Presentation::Canvas.new]
       subject['structures'] = [IIIF::V3::Presentation::Sequence.new]
       exp_err_msg = "All entries in the structures list must be a IIIF::V3::Presentation::Range"
       expect { subject.validate }.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
@@ -225,9 +112,7 @@ describe IIIF::V3::Presentation::Manifest do
     it 'raises no error when structures entry is a Range' do
       subject['id'] = manifest_id
       subject.label = {'en' => ['Book 1']}
-      seq = IIIF::V3::Presentation::Sequence.new
-      seq['items'] = [IIIF::V3::Presentation::Canvas.new]
-      subject['items'] = [seq]
+      subject['items'] = [IIIF::V3::Presentation::Canvas.new]
       subject['structures'] = [IIIF::V3::Presentation::Range.new]
       expect { subject.validate }.not_to raise_error
     end
@@ -241,11 +126,6 @@ describe IIIF::V3::Presentation::Manifest do
       "width" => 10108,
       "content" => []
     })}
-    let!(:default_sequence_object) {IIIF::V3::Presentation::Sequence.new({
-      "id" => "https://example.org/abc666#sequence-1",
-      "label" => {'en' => ['Current order']},
-      "items" => [canvas_object]
-    })}
     describe 'realistic(?) minimal manifest' do
       let!(:manifest_object) { described_class.new({
         "@context" => [
@@ -256,7 +136,7 @@ describe IIIF::V3::Presentation::Manifest do
         "label" => {"en" => ["blah"]},
         "attribution" => "bleah",
         "description" => "blargh",
-        "items" => [default_sequence_object]
+        "items" => [canvas_object]
       })}
       it 'validates' do
         expect{manifest_object.validate}.not_to raise_error
@@ -266,7 +146,7 @@ describe IIIF::V3::Presentation::Manifest do
         expect(manifest_object.id).to eq "https://example.org/abc666/iiif3/manifest"
         expect(manifest_object.label['en']).to include "blah"
         expect(manifest_object.items.size).to be 1
-        expect(manifest_object.items.first).to eq default_sequence_object
+        expect(manifest_object.items.first).to eq canvas_object
       end
       it 'has expected context' do
         expect(manifest_object['@context'].size).to be 2
@@ -301,7 +181,7 @@ describe IIIF::V3::Presentation::Manifest do
         "label" => {"en" => ["blah"]},
         "attribution" => "bleah",
         "description" => "blargh",
-        "sequences" => [default_sequence_object],
+        "items" => [canvas_object],
         "logo" => {
           "id" => "https://example.org/logo/full/400,/0/default.jpg",
           "service" => logo_service
@@ -334,10 +214,8 @@ describe IIIF::V3::Presentation::Manifest do
         expect(manifest_object.type).to eq 'Manifest'
         expect(manifest_object.id).to eq "https://example.org/abc666/iiif3/manifest"
         expect(manifest_object.label['en']).to include "blah"
-        # NOTE:  using sequences as Universal Viewer currently only accepts sequences
-        #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
-        expect(manifest_object.sequences.size).to be 1
-        expect(manifest_object.sequences.first).to eq default_sequence_object
+        expect(manifest_object.items.size).to be 1
+        expect(manifest_object.items.first).to eq canvas_object
       end
       it 'has expected string values' do
         expect(manifest_object.attribution).to eq "bleah"
@@ -351,15 +229,6 @@ describe IIIF::V3::Presentation::Manifest do
       end
 
       describe 'from stanford purl CODE' do
-        let!(:seq_object) {
-          s = IIIF::V3::Presentation::Sequence.new({
-          'id' => 'https://example.org/abc666#sequence-1',
-          "label" => {"en" => ["Current order"]},
-          })
-          s.viewingDirection = 'left-to-right'
-          s.canvases << canvas_object
-          s
-        }
         let!(:manifest_data) {
           {
             "id" => "https://example.org/abc666/iiif3/manifest",
@@ -384,7 +253,7 @@ describe IIIF::V3::Presentation::Manifest do
           ]
           m.description = 'blargh'
           m.thumbnail = [thumbnail_image]
-          m.sequences << seq_object
+          m.items << canvas_object
           m
         }
         it 'manifest validates' do
@@ -394,10 +263,8 @@ describe IIIF::V3::Presentation::Manifest do
           expect(manifest_object.type).to eq 'Manifest'
           expect(manifest_object.id).to eq "https://example.org/abc666/iiif3/manifest"
           expect(manifest_object.label['en']).to include "blah"
-          # NOTE:  using sequences as Universal Viewer currently only accepts sequences
-          #  see https://github.com/sul-dlss/osullivan/issues/27, sul-dlss/purl/issues/167
-          expect(manifest_object.sequences.size).to be 1
-          expect(manifest_object.sequences.first).to eq seq_object
+          expect(manifest_object.items.size).to be 1
+          expect(manifest_object.items.first).to eq canvas_object
         end
         it 'has expected string values' do
           expect(manifest_object.attribution).to eq "bleah"
@@ -486,7 +353,7 @@ describe IIIF::V3::Presentation::Manifest do
           "id" => "http://example.org/collections/books/",
           "type" => "Collection"
         }],
-        "items" => [default_sequence_object],
+        "items" => [canvas_object],
         "structures" => [range_object]
       })}
       it 'validates' do

--- a/spec/unit/iiif/v3/presentation/manifest_spec.rb
+++ b/spec/unit/iiif/v3/presentation/manifest_spec.rb
@@ -165,13 +165,12 @@ describe IIIF::V3::Presentation::Manifest do
 
     describe 'realistic example from Stanford purl manifests' do
       let!(:logo_service) { IIIF::V3::Presentation::Service.new({
-        "@context" => "http://iiif.io/api/image/2/context.json",
         "@id" => "https://example.org/logo",
+        "@type" => "ImageService2",
         "id" => "https://example.org/logo",
         "profile" => "http://iiif.io/api/image/2/level1.json"
         })}
       let!(:thumbnail_image_service) { IIIF::V3::Presentation::Service.new({
-        "@context" => IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_CONTEXT,
         "@id" => "https://example.org/image/iiif/abc666_05_0001",
         "id" => "https://example.org/image/iiif/abc666_05_0001",
         "profile" => IIIF::V3::Presentation::Service::IIIF_IMAGE_V2_LEVEL1_PROFILE
@@ -321,8 +320,8 @@ describe IIIF::V3::Presentation::Manifest do
           "id" => "http://example.org/images/book1-page1/full/80,100/0/default.jpg",
           "type" => "Image",
           "service" => {
-            "@context" => "http://iiif.io/api/image/2/context.json",
             "id" => "http://example.org/images/book1-page1",
+            "type" => "ImageService2",
             "profile" => ["http://iiif.io/api/image/2/level1.json"]
           }
         }],
@@ -339,8 +338,8 @@ describe IIIF::V3::Presentation::Manifest do
         "logo" => {
           "id" => "http://example.org/logos/institution1.jpg",
           "service" => {
-              "@context" => "http://iiif.io/api/image/2/context.json",
               "id" => "http://example.org/service/inst1",
+              "type" => "ImageService2",
               "profile" => ["http://iiif.io/api/image/2/profiles/level2.json"]
           }
         },
@@ -349,7 +348,6 @@ describe IIIF::V3::Presentation::Manifest do
           "format" => "video/mpeg"
         }],
         "service" => [{
-          "@context" => "http://example.org/ns/jsonld/context.json",
           "id" => "http://example.org/service/example",
           "profile" => ["http://example.org/docs/example-service.html"]
         }],

--- a/spec/unit/iiif/v3/presentation/manifest_spec.rb
+++ b/spec/unit/iiif/v3/presentation/manifest_spec.rb
@@ -134,7 +134,10 @@ describe IIIF::V3::Presentation::Manifest do
         ],
         "id" => "https://example.org/abc666/iiif3/manifest",
         "label" => {"en" => ["blah"]},
-        "attribution" => "bleah",
+        "requiredStatement" => {
+          "label": { "en": [ "Attribution" ] },
+          "value": { "en": [ "bleah" ] },
+        },
         "description" => "blargh",
         "items" => [canvas_object]
       })}
@@ -153,8 +156,10 @@ describe IIIF::V3::Presentation::Manifest do
         expect(manifest_object['@context']).to include(*IIIF::V3::Presentation::CONTEXT)
       end
       it 'has expected string values' do
-        expect(manifest_object.attribution).to eq "bleah"
         expect(manifest_object.description).to eq "blargh"
+      end
+      it 'has other values' do
+        expect(manifest_object['required_statement'][:value][:en].first).to eq 'bleah'
       end
     end
 
@@ -179,7 +184,10 @@ describe IIIF::V3::Presentation::Manifest do
       let!(:manifest_object) { described_class.new({
         "id" => "https://example.org/abc666/iiif3/manifest",
         "label" => {"en" => ["blah"]},
-        "attribution" => "bleah",
+        "requiredStatement" => {
+          "label": { "en": [ "Attribution" ] },
+          "value": { "en": [ "bleah" ] },
+        },
         "description" => "blargh",
         "items" => [canvas_object],
         "logo" => {
@@ -218,10 +226,10 @@ describe IIIF::V3::Presentation::Manifest do
         expect(manifest_object.items.first).to eq canvas_object
       end
       it 'has expected string values' do
-        expect(manifest_object.attribution).to eq "bleah"
         expect(manifest_object.description).to eq "blargh"
       end
       it 'has expected additional content' do
+        expect(manifest_object['required_statement'][:value][:en].first).to eq 'bleah'
         expect(manifest_object.logo.keys.size).to be 2
         expect(manifest_object.seeAlso.keys.size).to be 2
         expect(manifest_object.metadata.size).to be 2
@@ -233,7 +241,10 @@ describe IIIF::V3::Presentation::Manifest do
           {
             "id" => "https://example.org/abc666/iiif3/manifest",
             "label" => {"en" => ["blah"]},
-            "attribution" => "bleah",
+            "requiredStatement" => {
+              "label": { "en": [ "Attribution" ] },
+              "value": { "en": [ "bleah" ] },
+            },
             "logo" => {
               "id" => "https://example.org/logo/full/400,/0/default.jpg",
               "service" => logo_service
@@ -267,10 +278,10 @@ describe IIIF::V3::Presentation::Manifest do
           expect(manifest_object.items.first).to eq canvas_object
         end
         it 'has expected string values' do
-          expect(manifest_object.attribution).to eq "bleah"
           expect(manifest_object.description).to eq "blargh"
         end
         it 'has expected additional content' do
+          expect(manifest_object['required_statement'][:value][:en].first).to eq 'bleah'
           expect(manifest_object.logo.keys.size).to be 2
           expect(manifest_object.seeAlso.keys.size).to be 2
           expect(manifest_object.metadata.size).to be 2
@@ -321,7 +332,10 @@ describe IIIF::V3::Presentation::Manifest do
         "rights" => [{
           "id" =>"http://example.org/license.html",
           "format" => "text/html"}],
-        "attribution" => {"en" => ["Provided by Example Organization"]},
+        "requiredStatement" => {
+          "label": { "en": [ "Attribution" ] },
+          "value": { "en": [ "bleah" ] },
+        },
         "logo" => {
           "id" => "http://example.org/logos/institution1.jpg",
           "service" => {

--- a/spec/unit/iiif/v3/presentation/manifest_spec.rb
+++ b/spec/unit/iiif/v3/presentation/manifest_spec.rb
@@ -138,7 +138,7 @@ describe IIIF::V3::Presentation::Manifest do
           "label": { "en": [ "Attribution" ] },
           "value": { "en": [ "bleah" ] },
         },
-        "description" => "blargh",
+        'summary' => { 'en' => ['blargh'] },
         "items" => [canvas_object]
       })}
       it 'validates' do
@@ -155,11 +155,9 @@ describe IIIF::V3::Presentation::Manifest do
         expect(manifest_object['@context'].size).to be 2
         expect(manifest_object['@context']).to include(*IIIF::V3::Presentation::CONTEXT)
       end
-      it 'has expected string values' do
-        expect(manifest_object.description).to eq "blargh"
-      end
       it 'has other values' do
         expect(manifest_object['required_statement'][:value][:en].first).to eq 'bleah'
+        expect(manifest_object.summary['en'].first).to eq 'blargh'
       end
     end
 
@@ -187,7 +185,7 @@ describe IIIF::V3::Presentation::Manifest do
           "label": { "en": [ "Attribution" ] },
           "value": { "en": [ "bleah" ] },
         },
-        "description" => "blargh",
+        'summary' => { 'en' => ['blargh'] },
         "items" => [canvas_object],
         "logo" => {
           "id" => "https://example.org/logo/full/400,/0/default.jpg",
@@ -224,11 +222,9 @@ describe IIIF::V3::Presentation::Manifest do
         expect(manifest_object.items.size).to be 1
         expect(manifest_object.items.first).to eq canvas_object
       end
-      it 'has expected string values' do
-        expect(manifest_object.description).to eq "blargh"
-      end
       it 'has expected additional content' do
         expect(manifest_object['required_statement'][:value][:en].first).to eq 'bleah'
+        expect(manifest_object.summary['en'].first).to eq 'blargh'
         expect(manifest_object.logo.keys.size).to be 2
         expect(manifest_object.seeAlso.keys.size).to be 2
         expect(manifest_object.metadata.size).to be 2
@@ -261,7 +257,7 @@ describe IIIF::V3::Presentation::Manifest do
             { 'label' => 'title', 'value' => 'who wants to know?' },
             { 'label' => 'PublishDate', 'value' => 'sometime' }
           ]
-          m.description = 'blargh'
+          m.summary = { 'en' => ['blargh'] }
           m.thumbnail = [thumbnail_image]
           m.items << canvas_object
           m
@@ -276,11 +272,9 @@ describe IIIF::V3::Presentation::Manifest do
           expect(manifest_object.items.size).to be 1
           expect(manifest_object.items.first).to eq canvas_object
         end
-        it 'has expected string values' do
-          expect(manifest_object.description).to eq "blargh"
-        end
         it 'has expected additional content' do
           expect(manifest_object['required_statement'][:value][:en].first).to eq 'bleah'
+          expect(manifest_object.summary['en'].first).to eq 'blargh'
           expect(manifest_object.logo.keys.size).to be 2
           expect(manifest_object.seeAlso.keys.size).to be 2
           expect(manifest_object.metadata.size).to be 2
@@ -315,7 +309,7 @@ describe IIIF::V3::Presentation::Manifest do
           {"label" => {"en" => ["Source"]},
            "value" => {"@none" => ["<span>From: <a href=\"http://example.org/db/1.html\">Some Collection</a></span>"]}}
         ],
-        "description" => {"en" => ["A longer description of this example book. It should give some real information."]},
+        "summary" => {"en" => ["A longer description of this example book. It should give some real information."]},
         "thumbnail" => [{
           "id" => "http://example.org/images/book1-page1/full/80,100/0/default.jpg",
           "type" => "Image",

--- a/spec/unit/iiif/v3/presentation/resource_spec.rb
+++ b/spec/unit/iiif/v3/presentation/resource_spec.rb
@@ -147,14 +147,14 @@ describe IIIF::V3::Presentation::Resource do
           }
           let(:resource_object_w_login) {
             resource = resource_object
-            resource.service = login_service
+            resource.service = [login_service]
             resource
           }
           it 'validates' do
             expect{resource_object_w_login.validate}.not_to raise_error
           end
           it 'has expected service value' do
-            service_obj = resource_object_w_login.service
+            service_obj = resource_object_w_login.service.first
             expect(service_obj.class).to eq IIIF::V3::Presentation::Service
             expect(service_obj.keys.size).to eq 4
             expect(service_obj.id).to eq 'https://example.org/auth/iiif'

--- a/spec/unit/iiif/v3/presentation/service_spec.rb
+++ b/spec/unit/iiif/v3/presentation/service_spec.rb
@@ -50,7 +50,7 @@ describe IIIF::V3::Presentation::Service do
         'profile' => inner_service_profile
         })
       service_obj = described_class.new({
-        '@context' => described_class::IIIF_IMAGE_V2_CONTEXT,
+        'type' => described_class::IIIF_IMAGE_V2_TYPE,
         'id' => id_uri,
         'profile' => described_class::IIIF_IMAGE_V2_LEVEL1_PROFILE,
         'label' => label_val,
@@ -58,7 +58,7 @@ describe IIIF::V3::Presentation::Service do
       })
       expect(service_obj.keys.size).to eq 5
       expect(service_obj['id']).to eq id_uri
-      expect(service_obj['@context']).to eq described_class::IIIF_IMAGE_V2_CONTEXT
+      expect(service_obj['type']).to eq described_class::IIIF_IMAGE_V2_TYPE
       expect(service_obj['profile']).to eq described_class::IIIF_IMAGE_V2_LEVEL1_PROFILE
       expect(service_obj['label']).to eq label_val
       expect(service_obj['service'][0]['id']).to eq inner_service_id
@@ -91,31 +91,32 @@ describe IIIF::V3::Presentation::Service do
   end
 
   describe '#validate' do
-    describe '@context = IIIF_IMAGE_API_V2_CONTEXT' do
-      it 'must have a "@id"' do
+    describe 'type = IIIF_IMAGE_API_V2_TYPE' do
+      it 'must have a "@id" or "id"' do
         service_obj = described_class.new({
-          '@context' => described_class::IIIF_IMAGE_V2_CONTEXT,
-          'id' => id_uri,
+          'type' => described_class::IIIF_IMAGE_V2_TYPE,
+          'nope' => id_uri,
           'profile' => described_class::IIIF_IMAGE_V2_LEVEL1_PROFILE
           })
-        exp_err_msg = '@id is required for IIIF::V3::Presentation::Service with @context http://iiif.io/api/image/2/context.json'
+        exp_err_msg = 'id or @id values are required for IIIF::V3::Presentation::Service with type or @type ImageService2'
         expect{service_obj.validate}.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, exp_err_msg)
       end
-      it 'must have a profile' do
+      it 'should have a profile' do
         service_obj = described_class.new({
-          '@context' => described_class::IIIF_IMAGE_V2_CONTEXT,
+          '@type' => described_class::IIIF_IMAGE_V2_TYPE,
           '@id' => id_uri
           })
-        exp_err_msg = 'profile is required for IIIF::V3::Presentation::Service with @context http://iiif.io/api/image/2/context.json'
+        exp_err_msg = 'profile should be present for IIIF::V3::Presentation::Service with type or @type ImageService2'
         expect{service_obj.validate}.to raise_error(IIIF::V3::Presentation::MissingRequiredKeyError, exp_err_msg)
       end
-      it 'must have matching values for "@id" and "id" if both are specified' do
+      it 'should have matching values for "@id" and "id" if both are specified' do
         service_obj = described_class.new({
-          '@context' => described_class::IIIF_IMAGE_V2_CONTEXT,
+          '@type' => described_class::IIIF_IMAGE_V2_TYPE,
           '@id' => id_uri,
-          'id' => "#{id_uri}/foo"
+          'id' => "#{id_uri}/foo",
+          'profile' => described_class::IIIF_IMAGE_V2_LEVEL1_PROFILE
           })
-        exp_err_msg = 'id and @id values must match for IIIF::V3::Presentation::Service with @context http://iiif.io/api/image/2/context.json'
+        exp_err_msg = 'id and @id values must match for IIIF::V3::Presentation::Service with type or @type ImageService2'
         expect{service_obj.validate}.to raise_error(IIIF::V3::Presentation::IllegalValueError, exp_err_msg)
       end
     end
@@ -125,15 +126,15 @@ describe IIIF::V3::Presentation::Service do
     describe 'from Stanford purl manifests' do
       it 'iiif image v2 service' do
         service_obj = described_class.new({
-          '@context' => described_class::IIIF_IMAGE_V2_CONTEXT,
+          'type' => described_class::IIIF_IMAGE_V2_TYPE,
           'id' => id_uri,
           '@id' => id_uri,
           'profile' => described_class::IIIF_IMAGE_V2_LEVEL1_PROFILE
         })
         expect{service_obj.validate}.not_to raise_error
         expect(service_obj.keys.size).to eq 4
-        expect(service_obj.keys).to include('@context', '@id', 'id', 'profile')
-        expect(service_obj['@context']).to eq described_class::IIIF_IMAGE_V2_CONTEXT
+        expect(service_obj.keys).to include('type', '@id', 'id', 'profile')
+        expect(service_obj['type']).to eq described_class::IIIF_IMAGE_V2_TYPE
         expect(service_obj['id']).to eq id_uri
         expect(service_obj['@id']).to eq id_uri
         expect(service_obj['profile']).to eq described_class::IIIF_IMAGE_V2_LEVEL1_PROFILE
@@ -183,7 +184,7 @@ describe IIIF::V3::Presentation::Service do
           })
         expect{middle.validate}.not_to raise_error
         outer = described_class.new({
-          "@context" => described_class::IIIF_IMAGE_V2_CONTEXT,
+            "@type" => described_class::IIIF_IMAGE_V2_TYPE,
             "@id" => "https://example.org/iiif/yy816tv6021_img_1",
             "id" => "https://example.org/iiif/yy816tv6021_img_1",
             "profile" => described_class::IIIF_IMAGE_V2_LEVEL1_PROFILE,
@@ -195,7 +196,7 @@ describe IIIF::V3::Presentation::Service do
     describe 'example from http://prezi3.iiif.io/api/presentation/3.0' do
       it 'iiif image v2' do
         service_obj = described_class.new({
-          "@context" => "http://iiif.io/api/image/2/context.json",
+          "type" => described_class::IIIF_IMAGE_V2_TYPE,
           "id" => "http://example.org/images/book1-page2",
           "@id" => "http://example.org/images/book1-page2",
           "profile" => "http://iiif.io/api/image/2/level1.json",
@@ -204,7 +205,7 @@ describe IIIF::V3::Presentation::Service do
           "tiles" => [{"width" => 512, "scaleFactors" => [1,2,4,8,16]}]
         })
         expect(service_obj.keys.size).to eq 7
-        expect(service_obj['@context']).to eq described_class::IIIF_IMAGE_V2_CONTEXT
+        expect(service_obj['type']).to eq described_class::IIIF_IMAGE_V2_TYPE
         expect(service_obj['id']).to eq 'http://example.org/images/book1-page2'
         expect(service_obj['@id']).to eq 'http://example.org/images/book1-page2'
         expect(service_obj['profile']).to eq described_class::IIIF_IMAGE_V2_LEVEL1_PROFILE


### PR DESCRIPTION
- ✅ Merge #32 first to update CI build.
- ✅ Update `label` to be an object See: https://iiif.io/api/presentation/3.0/change-log/#133-use-language-map-pattern-for-label-value-summary
- ✅ Remove Sequence in favor of Ranges, items, and behavior value sequence See: https://iiif.io/api/presentation/3.0/change-log/#141-remove-sequence-in-favor-of-ranges-items-and-behavior-value-sequence
- ✅ Rename attribution to requiredStatement, allow label+value https://iiif.io/api/presentation/3.0/change-log/#122-rename-viewinghint-to-behavior
- ✅ Context must not be present on any included resources
- ✅ A service must be an array
- ✅ Rename description to summary see https://iiif.io/api/presentation/3.0/change-log/#126-rename-description-to-summaryq

Manifests generated using this have been validated against the latest version of the IIIF Presentation v3.0 validator. github.com/IIIF/presentation-validator
